### PR TITLE
API correctness: real HTTP statuses, validation, atomic cascade deletes

### DIFF
--- a/app/api/planner/boards/[boardId]/categories/[categoryId]/route.ts
+++ b/app/api/planner/boards/[boardId]/categories/[categoryId]/route.ts
@@ -1,5 +1,6 @@
-// pages/api/planner/boards/[boardId]/categories/[categoryId]/route.ts
-import { ExtendedNextRequest, Params, withMiddleware } from '@/lib/middleware'
+import { UNASSIGNED_CATEGORY_ID } from '@/constants/constants'
+import { categoryId as categoryIdSchema, entityId } from '@/lib/apiSchemas'
+import { ExtendedNextRequest, Params, jsonError, withMiddleware } from '@/lib/middleware'
 import Planner from '@/models/Planner'
 import { NextResponse } from 'next/server'
 
@@ -7,23 +8,39 @@ export const DELETE = withMiddleware(
   async (req: ExtendedNextRequest, { params }: { params: Params }): Promise<NextResponse> => {
     const { userId } = req
     const { boardId, categoryId } = params
+    if (!entityId.safeParse(boardId).success) {
+      return jsonError(400, 'Invalid board id')
+    }
+    if (!categoryIdSchema.safeParse(categoryId).success) {
+      return jsonError(400, 'Invalid category id')
+    }
+    if (categoryId === UNASSIGNED_CATEGORY_ID) {
+      return jsonError(400, 'The default category cannot be deleted')
+    }
 
-    const docs = await Planner.findOne({ clerkUserId: userId })
-    const updateObject: any = {}
+    const planner = await Planner.findOne({ clerkUserId: userId }).lean()
+    if (!planner || !planner.categories[categoryId!]) {
+      return jsonError(404, 'Category not found')
+    }
 
-    for (const [key, value] of Object.entries(docs.taskCards)) {
-      if ((value as any).category === categoryId) {
-        updateObject[`taskCards.${key}.category`] = 'unassigned'
+    const reassignedCards = Object.fromEntries(
+      Object.entries(planner.taskCards)
+        .filter(([, taskCard]) => taskCard.category === categoryId)
+        .map(([taskCardId]) => [`taskCards.${taskCardId}.category`, UNASSIGNED_CATEGORY_ID])
+    )
+
+    const result = await Planner.updateOne(
+      { clerkUserId: userId, [`categories.${categoryId}.id`]: categoryId },
+      {
+        $unset: { [`categories.${categoryId}`]: '' },
+        $pull: { [`boards.${boardId}.categories`]: categoryId },
+        ...(Object.keys(reassignedCards).length > 0 && { $set: reassignedCards }),
       }
+    )
+    if (result.matchedCount === 0) {
+      return jsonError(404, 'Category not found')
     }
 
-    if (Object.keys(updateObject).length > 0) {
-      await Planner.updateOne({ clerkUserId: userId }, { $set: updateObject })
-    }
-
-    await Planner.updateOne({ clerkUserId: userId }, { $unset: { [`categories.${categoryId}`]: '' } })
-    await Planner.updateOne({ clerkUserId: userId }, { $pull: { [`boards.${boardId}.categories`]: categoryId } })
-
-    return NextResponse.json({ status: 204 })
+    return NextResponse.json({ deleted: categoryId }, { status: 200 })
   }
 )

--- a/app/api/planner/boards/[boardId]/categories/route.ts
+++ b/app/api/planner/boards/[boardId]/categories/route.ts
@@ -1,32 +1,31 @@
-// pages/api/planner/boards/[boardId]/categories/route.ts
-import { ExtendedNextRequest, Params, withMiddleware } from '@/lib/middleware'
+import { categoryCreate, entityId } from '@/lib/apiSchemas'
+import { ExtendedNextRequest, Params, jsonError, parseBody, withMiddleware } from '@/lib/middleware'
 import Planner from '@/models/Planner'
 import { NextResponse } from 'next/server'
-
-interface AddNewCategoryRequestBody {
-  newCategoryDetails: { id: string; [key: string]: any }
-}
 
 export const POST = withMiddleware(
   async (req: ExtendedNextRequest, { params }: { params: Params }): Promise<NextResponse> => {
     const { userId } = req
     const { boardId } = params
-    const { newCategoryDetails }: AddNewCategoryRequestBody = await req.json()
+    if (!entityId.safeParse(boardId).success) {
+      return jsonError(400, 'Invalid board id')
+    }
 
-    await Planner.updateOne(
-      { clerkUserId: userId },
+    const body = await parseBody(req, categoryCreate)
+    if (body.error) return body.error
+    const { newCategoryDetails } = body.data
+
+    const result = await Planner.updateOne(
+      { clerkUserId: userId, [`boards.${boardId}.id`]: boardId },
       {
-        $set: {
-          [`categories.${newCategoryDetails.id}`]: newCategoryDetails,
-        },
+        $set: { [`categories.${newCategoryDetails.id}`]: newCategoryDetails },
+        $push: { [`boards.${boardId}.categories`]: newCategoryDetails.id },
       }
     )
+    if (result.matchedCount === 0) {
+      return jsonError(404, 'Board not found')
+    }
 
-    await Planner.updateOne(
-      { clerkUserId: userId },
-      { $push: { [`boards.${boardId}.categories`]: newCategoryDetails.id } }
-    )
-
-    return NextResponse.json({ status: 201 })
+    return NextResponse.json({ categoryId: newCategoryDetails.id }, { status: 201 })
   }
 )

--- a/app/api/planner/boards/[boardId]/columns/[columnId]/route.ts
+++ b/app/api/planner/boards/[boardId]/columns/[columnId]/route.ts
@@ -1,25 +1,54 @@
-// pages/api/planner/boards/[boardId]/columns/[columnId]/route.ts
-import { ExtendedNextRequest, Params, withMiddleware } from '@/lib/middleware'
+import { entityId } from '@/lib/apiSchemas'
+import { ExtendedNextRequest, jsonError, Params, withMiddleware } from '@/lib/middleware'
 import Planner from '@/models/Planner'
 import { NextResponse } from 'next/server'
 
 export const DELETE = withMiddleware(
   async (req: ExtendedNextRequest, { params }: { params: Params }): Promise<NextResponse> => {
     const { userId } = req
-    const { boardId, columnId } = params
+    const boardIdResult = entityId.safeParse(params.boardId)
+    if (!boardIdResult.success) {
+      return jsonError(400, 'Invalid board id')
+    }
+    const columnIdResult = entityId.safeParse(params.columnId)
+    if (!columnIdResult.success) {
+      return jsonError(400, 'Invalid column id')
+    }
+    const boardId = boardIdResult.data
+    const columnId = columnIdResult.data
 
-    await Planner.updateOne(
-      { clerkUserId: userId },
+    const planner = await Planner.findOne({ clerkUserId: userId }).lean()
+    if (!planner || !planner.boards?.[boardId]) {
+      return jsonError(404, 'Board not found')
+    }
+    const column = planner.columns?.[columnId]
+    if (!column) {
+      return jsonError(404, 'Column not found')
+    }
+
+    // Cascade: the column, its cards, and those cards' subtasks — all removed
+    // in a single atomic update.
+    const unset: Record<string, ''> = { [`columns.${columnId}`]: '' }
+    for (const cardId of column.taskCards) {
+      unset[`taskCards.${cardId}`] = ''
+      for (const subTaskId of planner.taskCards?.[cardId]?.subTasks ?? []) {
+        unset[`subTasks.${subTaskId}`] = ''
+      }
+    }
+
+    const result = await Planner.updateOne(
+      { clerkUserId: userId, [`columns.${columnId}.id`]: columnId },
       {
+        $unset: unset,
         $pull: {
           [`boards.${boardId}.columns`]: columnId,
         },
-        $unset: {
-          [`columns.${columnId}`]: 1,
-        },
       }
     )
+    if (result.matchedCount === 0) {
+      return jsonError(404, 'Column not found')
+    }
 
-    return NextResponse.json({ status: 204 })
+    return NextResponse.json({ deleted: columnId })
   }
 )

--- a/app/api/planner/boards/[boardId]/columns/reorder/route.ts
+++ b/app/api/planner/boards/[boardId]/columns/reorder/route.ts
@@ -1,22 +1,30 @@
-import { ExtendedNextRequest, Params, withMiddleware } from '@/lib/middleware'
+import { columnReorder, entityId } from '@/lib/apiSchemas'
+import { ExtendedNextRequest, jsonError, Params, parseBody, withMiddleware } from '@/lib/middleware'
 import Planner from '@/models/Planner'
 import { NextResponse } from 'next/server'
-
-interface ChangeColumnOrderRequestBody {
-  newColumnOrder: string[]
-}
 
 export const PATCH = withMiddleware(
   async (req: ExtendedNextRequest, { params }: { params: Params }): Promise<NextResponse> => {
     const { userId } = req
-    const { boardId } = params
-    const { newColumnOrder }: ChangeColumnOrderRequestBody = await req.json()
+    const boardIdResult = entityId.safeParse(params.boardId)
+    if (!boardIdResult.success) {
+      return jsonError(400, 'Invalid board id')
+    }
+    const boardId = boardIdResult.data
+    const body = await parseBody(req, columnReorder)
+    if (body.error) {
+      return body.error
+    }
+    const { newColumnOrder } = body.data
 
-    await Planner.updateOne(
+    const result = await Planner.updateOne(
       { clerkUserId: userId, [`boards.${boardId}.id`]: boardId },
       { $set: { [`boards.${boardId}.columns`]: newColumnOrder } }
     )
+    if (result.matchedCount === 0) {
+      return jsonError(404, 'Board not found')
+    }
 
-    return NextResponse.json({ status: 204 })
+    return NextResponse.json({ updated: boardId })
   }
 )

--- a/app/api/planner/boards/[boardId]/columns/route.ts
+++ b/app/api/planner/boards/[boardId]/columns/route.ts
@@ -1,21 +1,24 @@
-// pages/api/planner/boards/[boardId]/columns/route.ts
-import { ExtendedNextRequest, Params, withMiddleware } from '@/lib/middleware'
+import { columnCreate, entityId } from '@/lib/apiSchemas'
+import { ExtendedNextRequest, jsonError, Params, parseBody, withMiddleware } from '@/lib/middleware'
 import Planner from '@/models/Planner'
 import { NextResponse } from 'next/server'
-
-interface AddNewColumnRequestBody {
-  newColumnDetails: { id: string; [key: string]: any }
-  updatedColumns: string[]
-}
 
 export const POST = withMiddleware(
   async (req: ExtendedNextRequest, { params }: { params: Params }): Promise<NextResponse> => {
     const { userId } = req
-    const { boardId } = params
-    const { newColumnDetails, updatedColumns }: AddNewColumnRequestBody = await req.json()
+    const boardIdResult = entityId.safeParse(params.boardId)
+    if (!boardIdResult.success) {
+      return jsonError(400, 'Invalid board id')
+    }
+    const boardId = boardIdResult.data
+    const body = await parseBody(req, columnCreate)
+    if (body.error) {
+      return body.error
+    }
+    const { newColumnDetails, updatedColumns } = body.data
 
-    await Planner.updateOne(
-      { clerkUserId: userId },
+    const result = await Planner.updateOne(
+      { clerkUserId: userId, [`boards.${boardId}.id`]: boardId },
       {
         $set: {
           [`boards.${boardId}.columns`]: updatedColumns,
@@ -23,7 +26,10 @@ export const POST = withMiddleware(
         },
       }
     )
+    if (result.matchedCount === 0) {
+      return jsonError(404, 'Board not found')
+    }
 
-    return NextResponse.json({ status: 201 })
+    return NextResponse.json({ columnId: newColumnDetails.id }, { status: 201 })
   }
 )

--- a/app/api/planner/boards/[boardId]/route.ts
+++ b/app/api/planner/boards/[boardId]/route.ts
@@ -1,35 +1,83 @@
-import { ExtendedNextRequest, Params, withMiddleware } from '@/lib/middleware'
+import { UNASSIGNED_CATEGORY_ID } from '@/constants/constants'
+import { boardPatch, entityId } from '@/lib/apiSchemas'
+import { ExtendedNextRequest, jsonError, Params, parseBody, withMiddleware } from '@/lib/middleware'
 import Planner from '@/models/Planner'
 import { NextResponse } from 'next/server'
 
 export const PATCH = withMiddleware(async (req: ExtendedNextRequest, { params }: { params: Params }) => {
   const { userId } = req
-  const { boardId } = params
-  const { newName } = await req.json()
-  await Planner.updateOne(
-    { clerkUserId: userId },
+  const boardIdResult = entityId.safeParse(params.boardId)
+  if (!boardIdResult.success) {
+    return jsonError(400, 'Invalid board id')
+  }
+  const boardId = boardIdResult.data
+  const body = await parseBody(req, boardPatch)
+  if (body.error) {
+    return body.error
+  }
+  const { newName } = body.data
+
+  const result = await Planner.updateOne(
+    { clerkUserId: userId, [`boards.${boardId}.id`]: boardId },
     {
       $set: {
         [`boards.${boardId}.name`]: newName,
       },
     }
   )
-  return NextResponse.json({ status: 200 })
+  if (result.matchedCount === 0) {
+    return jsonError(404, 'Board not found')
+  }
+  return NextResponse.json({ updated: boardId })
 })
 
 export const DELETE = withMiddleware(async (req: ExtendedNextRequest, { params }: { params: Params }) => {
   const { userId } = req
-  const { boardId } = params
-  await Planner.updateOne(
-    { clerkUserId: userId },
+  const boardIdResult = entityId.safeParse(params.boardId)
+  if (!boardIdResult.success) {
+    return jsonError(400, 'Invalid board id')
+  }
+  const boardId = boardIdResult.data
+
+  const planner = await Planner.findOne({ clerkUserId: userId }).lean()
+  const board = planner?.boards?.[boardId]
+  if (!planner || !board) {
+    return jsonError(404, 'Board not found')
+  }
+
+  // Cascade: the board itself, its columns, their cards, those cards' subtasks,
+  // and the board's categories — all removed in a single atomic update.
+  const unset: Record<string, ''> = { [`boards.${boardId}`]: '' }
+  for (const columnId of board.columns) {
+    unset[`columns.${columnId}`] = ''
+    for (const cardId of planner.columns?.[columnId]?.taskCards ?? []) {
+      unset[`taskCards.${cardId}`] = ''
+      for (const subTaskId of planner.taskCards?.[cardId]?.subTasks ?? []) {
+        unset[`subTasks.${subTaskId}`] = ''
+      }
+    }
+  }
+  // The 'unassigned' category id is shared by every board, so it only goes when
+  // this is the last board standing.
+  const otherBoardExists = Object.keys(planner.boards).some((id) => id !== boardId)
+  for (const categoryId of board.categories) {
+    if (categoryId === UNASSIGNED_CATEGORY_ID && otherBoardExists) {
+      continue
+    }
+    unset[`categories.${categoryId}`] = ''
+  }
+
+  const result = await Planner.updateOne(
+    { clerkUserId: userId, [`boards.${boardId}.id`]: boardId },
     {
+      $unset: unset,
       $pull: {
         boardOrder: boardId,
       },
-      $unset: {
-        [`boards.${boardId}`]: '',
-      },
     }
   )
-  return NextResponse.json({ status: 204 })
+  if (result.matchedCount === 0) {
+    return jsonError(404, 'Board not found')
+  }
+  return NextResponse.json({ deleted: boardId })
 })

--- a/app/api/planner/boards/route.ts
+++ b/app/api/planner/boards/route.ts
@@ -1,11 +1,17 @@
-import { ExtendedNextRequest, withMiddleware } from '@/lib/middleware'
+import { boardCreate } from '@/lib/apiSchemas'
+import { ExtendedNextRequest, jsonError, parseBody, withMiddleware } from '@/lib/middleware'
 import Planner from '@/models/Planner'
 import { NextResponse } from 'next/server'
 
 export const POST = withMiddleware(async (req: ExtendedNextRequest) => {
   const { userId } = req
-  const { boardId, boardName, unassignedCategoryDetails } = await req.json()
-  await Planner.updateMany(
+  const body = await parseBody(req, boardCreate)
+  if (body.error) {
+    return body.error
+  }
+  const { boardId, boardName, unassignedCategoryDetails } = body.data
+
+  const result = await Planner.updateOne(
     { clerkUserId: userId },
     {
       $push: {
@@ -22,5 +28,8 @@ export const POST = withMiddleware(async (req: ExtendedNextRequest) => {
       },
     }
   )
-  return NextResponse.json({ status: 201 })
+  if (result.matchedCount === 0) {
+    return jsonError(404, 'Planner not found')
+  }
+  return NextResponse.json({ boardId }, { status: 201 })
 })

--- a/app/api/planner/cards/[cardId]/move/route.ts
+++ b/app/api/planner/cards/[cardId]/move/route.ts
@@ -1,31 +1,47 @@
-import { ExtendedNextRequest, withMiddleware } from '@/lib/middleware'
+import { cardMove, entityId } from '@/lib/apiSchemas'
+import { ExtendedNextRequest, Params, jsonError, parseBody, withMiddleware } from '@/lib/middleware'
 import Planner from '@/models/Planner'
 import { NextResponse } from 'next/server'
 
-interface MoveCardRequestBody {
-  sourceColumnId: string
-  destColumnId: string
-  sourceColumnTaskCardIds: string[]
-  destColumnTaskCardIds: string[]
-}
+export const PATCH = withMiddleware(
+  async (req: ExtendedNextRequest, { params }: { params: Params }): Promise<NextResponse> => {
+    const { userId } = req
 
-export const PATCH = withMiddleware(async (req: ExtendedNextRequest): Promise<NextResponse> => {
-  const { userId } = req
-  const { sourceColumnId, destColumnId, sourceColumnTaskCardIds, destColumnTaskCardIds }: MoveCardRequestBody =
-    await req.json()
-
-  await Planner.updateMany(
-    {
-      clerkUserId: userId,
-      $or: [{ [`columns.${sourceColumnId}.id`]: sourceColumnId }, { [`columns.${destColumnId}.id`]: destColumnId }],
-    },
-    {
-      $set: {
-        [`columns.${sourceColumnId}.taskCards`]: sourceColumnTaskCardIds,
-        [`columns.${destColumnId}.taskCards`]: destColumnTaskCardIds,
-      },
+    const parsedCardId = entityId.safeParse(params.cardId)
+    if (!parsedCardId.success) {
+      return jsonError(400, 'Invalid card id')
     }
-  )
+    const cardId = parsedCardId.data
 
-  return NextResponse.json({ status: 204 })
-})
+    const body = await parseBody(req, cardMove)
+    if (body.error) {
+      return body.error
+    }
+    const { sourceColumnId, destColumnId, sourceColumnTaskCardIds, destColumnTaskCardIds } = body.data
+
+    if (!destColumnTaskCardIds.includes(cardId)) {
+      return jsonError(400, 'Moved card must appear in the destination column card list')
+    }
+
+    // Both columns must exist — prevents the half-applied update the old $or filter allowed.
+    const result = await Planner.updateOne(
+      {
+        clerkUserId: userId,
+        [`columns.${sourceColumnId}.id`]: sourceColumnId,
+        [`columns.${destColumnId}.id`]: destColumnId,
+      },
+      {
+        $set: {
+          [`columns.${sourceColumnId}.taskCards`]: sourceColumnTaskCardIds,
+          [`columns.${destColumnId}.taskCards`]: destColumnTaskCardIds,
+        },
+      }
+    )
+
+    if (result.matchedCount === 0) {
+      return jsonError(404, 'Column not found')
+    }
+
+    return NextResponse.json({ ok: true }, { status: 200 })
+  }
+)

--- a/app/api/planner/cards/[cardId]/route.ts
+++ b/app/api/planner/cards/[cardId]/route.ts
@@ -1,30 +1,51 @@
-import { ExtendedNextRequest, Params, withMiddleware } from '@/lib/middleware'
+import { cardPatch, entityId } from '@/lib/apiSchemas'
+import { ExtendedNextRequest, Params, jsonError, parseBody, withMiddleware } from '@/lib/middleware'
 import Planner from '@/models/Planner'
 import { NextResponse } from 'next/server'
-
-interface CardModificationRequestBody {
-  title?: string
-  content?: string
-  status?: string
-  category?: string
-}
 
 export const PATCH = withMiddleware(
   async (req: ExtendedNextRequest, { params }: { params: Params }): Promise<NextResponse> => {
     const { userId } = req
-    const { cardId } = params
-    const body: CardModificationRequestBody = await req.json()
 
-    const [key, value] = Object.entries(body)[0]
-    const updateField = { [`taskCards.${cardId}.${key}`]: value }
+    const parsedCardId = entityId.safeParse(params.cardId)
+    if (!parsedCardId.success) {
+      return jsonError(400, 'Invalid card id')
+    }
+    const cardId = parsedCardId.data
 
-    await Planner.updateOne(
-      { clerkUserId: userId },
-      {
-        $set: updateField,
-      }
-    )
+    const body = await parseBody(req, cardPatch)
+    if (body.error) {
+      return body.error
+    }
+    const { title, content, status, category, columnId, taskCardOrder } = body.data
 
-    return NextResponse.json({ status: 204 })
+    // Explicit allowlist — body keys never reach the $set path directly.
+    const update: Record<string, unknown> = {}
+    if (title !== undefined) {
+      update[`taskCards.${cardId}.title`] = title
+    }
+    if (content !== undefined) {
+      update[`taskCards.${cardId}.content`] = content
+    }
+    if (status !== undefined) {
+      update[`taskCards.${cardId}.status`] = status
+    }
+    if (category !== undefined) {
+      update[`taskCards.${cardId}.category`] = category
+    }
+
+    const filter: Record<string, unknown> = { clerkUserId: userId, [`taskCards.${cardId}.id`]: cardId }
+    if (columnId !== undefined && taskCardOrder !== undefined) {
+      filter[`columns.${columnId}.id`] = columnId
+      update[`columns.${columnId}.taskCards`] = taskCardOrder
+    }
+
+    const result = await Planner.updateOne(filter, { $set: update })
+
+    if (result.matchedCount === 0) {
+      return jsonError(404, 'Card not found')
+    }
+
+    return NextResponse.json({ ok: true }, { status: 200 })
   }
 )

--- a/app/api/planner/cards/[cardId]/subtasks/[subTaskId]/route.ts
+++ b/app/api/planner/cards/[cardId]/subtasks/[subTaskId]/route.ts
@@ -1,21 +1,36 @@
-import { ExtendedNextRequest, Params, withMiddleware } from '@/lib/middleware'
+import { entityId } from '@/lib/apiSchemas'
+import { ExtendedNextRequest, Params, jsonError, withMiddleware } from '@/lib/middleware'
 import Planner from '@/models/Planner'
 import { NextResponse } from 'next/server'
 
 export const DELETE = withMiddleware(
   async (req: ExtendedNextRequest, { params }: { params: Params }): Promise<NextResponse> => {
     const { userId } = req
-    const { cardId, subTaskId } = params
 
-    // Remove the subtask from the subtask object using $unset
-    await Planner.updateOne({ clerkUserId: userId }, { $unset: { [`subTasks.${subTaskId}`]: '' } })
+    const parsedCardId = entityId.safeParse(params.cardId)
+    if (!parsedCardId.success) {
+      return jsonError(400, 'Invalid card id')
+    }
+    const parsedSubTaskId = entityId.safeParse(params.subTaskId)
+    if (!parsedSubTaskId.success) {
+      return jsonError(400, 'Invalid subtask id')
+    }
+    const cardId = parsedCardId.data
+    const subTaskId = parsedSubTaskId.data
 
-    // Remove the subtask from the subtask list within the specified taskcard using $pull
-    await Planner.updateOne(
+    // Remove the subtask entry and its reference in the card's order array atomically.
+    const result = await Planner.updateOne(
       { clerkUserId: userId, [`taskCards.${cardId}.id`]: cardId },
-      { $pull: { [`taskCards.${cardId}.subTasks`]: subTaskId } }
+      {
+        $unset: { [`subTasks.${subTaskId}`]: '' },
+        $pull: { [`taskCards.${cardId}.subTasks`]: subTaskId },
+      }
     )
 
-    return NextResponse.json({ status: 204 })
+    if (result.matchedCount === 0) {
+      return jsonError(404, 'Card not found')
+    }
+
+    return NextResponse.json({ deleted: subTaskId })
   }
 )

--- a/app/api/planner/cards/[cardId]/subtasks/move/route.ts
+++ b/app/api/planner/cards/[cardId]/subtasks/move/route.ts
@@ -1,23 +1,33 @@
-// pages/api/planner/cards/[taskCardId]/subtasks/move/route.ts
-import { ExtendedNextRequest, Params, withMiddleware } from '@/lib/middleware'
+import { entityId, subTaskReorder } from '@/lib/apiSchemas'
+import { ExtendedNextRequest, Params, jsonError, parseBody, withMiddleware } from '@/lib/middleware'
 import Planner from '@/models/Planner'
 import { NextResponse } from 'next/server'
-
-interface MoveSubtaskRequestBody {
-  reorderedSubTasks: string[]
-}
 
 export const PATCH = withMiddleware(
   async (req: ExtendedNextRequest, { params }: { params: Params }): Promise<NextResponse> => {
     const { userId } = req
-    const { cardId } = params
-    const { reorderedSubTasks }: MoveSubtaskRequestBody = await req.json()
 
-    await Planner.updateOne(
+    const parsedCardId = entityId.safeParse(params.cardId)
+    if (!parsedCardId.success) {
+      return jsonError(400, 'Invalid card id')
+    }
+    const cardId = parsedCardId.data
+
+    const body = await parseBody(req, subTaskReorder)
+    if (body.error) {
+      return body.error
+    }
+    const { reorderedSubTasks } = body.data
+
+    const result = await Planner.updateOne(
       { clerkUserId: userId, [`taskCards.${cardId}.id`]: cardId },
       { $set: { [`taskCards.${cardId}.subTasks`]: reorderedSubTasks } }
     )
 
-    return NextResponse.json({ status: 204 })
+    if (result.matchedCount === 0) {
+      return jsonError(404, 'Card not found')
+    }
+
+    return NextResponse.json({ ok: true })
   }
 )

--- a/app/api/planner/cards/[cardId]/subtasks/route.ts
+++ b/app/api/planner/cards/[cardId]/subtasks/route.ts
@@ -1,21 +1,26 @@
-// pages/api/planner/cards/[taskCardId]/subtasks/route.ts
-import { ExtendedNextRequest, Params, withMiddleware } from '@/lib/middleware'
+import { entityId, subTaskCreate } from '@/lib/apiSchemas'
+import { ExtendedNextRequest, Params, jsonError, parseBody, withMiddleware } from '@/lib/middleware'
 import Planner from '@/models/Planner'
 import { NextResponse } from 'next/server'
-
-interface AddNewSubTaskRequestBody {
-  newSubTaskDetails: { id: string; [key: string]: any }
-  newSubTasksOrder: string[]
-}
 
 export const POST = withMiddleware(
   async (req: ExtendedNextRequest, { params }: { params: Params }): Promise<NextResponse> => {
     const { userId } = req
-    const { cardId } = params
-    const { newSubTaskDetails, newSubTasksOrder }: AddNewSubTaskRequestBody = await req.json()
 
-    await Planner.updateOne(
-      { clerkUserId: userId },
+    const parsedCardId = entityId.safeParse(params.cardId)
+    if (!parsedCardId.success) {
+      return jsonError(400, 'Invalid card id')
+    }
+    const cardId = parsedCardId.data
+
+    const body = await parseBody(req, subTaskCreate)
+    if (body.error) {
+      return body.error
+    }
+    const { newSubTaskDetails, newSubTasksOrder } = body.data
+
+    const result = await Planner.updateOne(
+      { clerkUserId: userId, [`taskCards.${cardId}.id`]: cardId },
       {
         $set: {
           [`taskCards.${cardId}.subTasks`]: newSubTasksOrder,
@@ -24,6 +29,10 @@ export const POST = withMiddleware(
       }
     )
 
-    return NextResponse.json({ status: 201 })
+    if (result.matchedCount === 0) {
+      return jsonError(404, 'Card not found')
+    }
+
+    return NextResponse.json({ subTaskId: newSubTaskDetails.id }, { status: 201 })
   }
 )

--- a/app/api/planner/categories/[categoryId]/route.ts
+++ b/app/api/planner/categories/[categoryId]/route.ts
@@ -1,21 +1,22 @@
-// pages/api/planner/categories/[categoryId]/route.ts
-import { ExtendedNextRequest, Params, withMiddleware } from '@/lib/middleware'
+import { categoryId as categoryIdSchema, categoryPatch } from '@/lib/apiSchemas'
+import { ExtendedNextRequest, Params, jsonError, parseBody, withMiddleware } from '@/lib/middleware'
 import Planner from '@/models/Planner'
 import { NextResponse } from 'next/server'
-
-interface ChangeCategoryInfoRequestBody {
-  newName: string
-  newColor: string
-}
 
 export const PATCH = withMiddleware(
   async (req: ExtendedNextRequest, { params }: { params: Params }): Promise<NextResponse> => {
     const { userId } = req
     const { categoryId } = params
-    const { newName, newColor }: ChangeCategoryInfoRequestBody = await req.json()
+    if (!categoryIdSchema.safeParse(categoryId).success) {
+      return jsonError(400, 'Invalid category id')
+    }
 
-    await Planner.updateOne(
-      { clerkUserId: userId },
+    const body = await parseBody(req, categoryPatch)
+    if (body.error) return body.error
+    const { newName, newColor } = body.data
+
+    const result = await Planner.updateOne(
+      { clerkUserId: userId, [`categories.${categoryId}.id`]: categoryId },
       {
         $set: {
           [`categories.${categoryId}.name`]: newName,
@@ -23,7 +24,10 @@ export const PATCH = withMiddleware(
         },
       }
     )
+    if (result.matchedCount === 0) {
+      return jsonError(404, 'Category not found')
+    }
 
-    return NextResponse.json({ status: 201 })
+    return NextResponse.json({ ok: true }, { status: 200 })
   }
 )

--- a/app/api/planner/columns/[columnId]/cards/[cardId]/route.ts
+++ b/app/api/planner/columns/[columnId]/cards/[cardId]/route.ts
@@ -1,19 +1,47 @@
-import { ExtendedNextRequest, Params, withMiddleware } from '@/lib/middleware'
+import { entityId } from '@/lib/apiSchemas'
+import { ExtendedNextRequest, Params, jsonError, withMiddleware } from '@/lib/middleware'
 import Planner from '@/models/Planner'
 import { NextResponse } from 'next/server'
 
 export const DELETE = withMiddleware(
   async (req: ExtendedNextRequest, { params }: { params: Params }): Promise<NextResponse> => {
     const { userId } = req
-    const { columnId, cardId } = params
 
-    await Planner.updateOne({ clerkUserId: userId }, { $unset: { [`taskCards.${cardId}`]: '' } })
+    const parsedColumnId = entityId.safeParse(params.columnId)
+    if (!parsedColumnId.success) {
+      return jsonError(400, 'Invalid column id')
+    }
+    const parsedCardId = entityId.safeParse(params.cardId)
+    if (!parsedCardId.success) {
+      return jsonError(400, 'Invalid card id')
+    }
+    const columnId = parsedColumnId.data
+    const cardId = parsedCardId.data
 
-    await Planner.updateOne(
-      { clerkUserId: userId, [`columns.${columnId}.id`]: columnId },
-      { $pull: { [`columns.${columnId}.taskCards`]: cardId } }
+    const planner = await Planner.findOne({ clerkUserId: userId }).lean()
+    const card = planner?.taskCards?.[cardId]
+    if (!planner || !card) {
+      return jsonError(404, 'Card not found')
+    }
+
+    // Cascade: the card and its subtasks go together, in one atomic update.
+    const unset: Record<string, ''> = { [`taskCards.${cardId}`]: '' }
+    for (const subTaskId of card.subTasks) {
+      unset[`subTasks.${subTaskId}`] = ''
+    }
+
+    const result = await Planner.updateOne(
+      { clerkUserId: userId, [`taskCards.${cardId}.id`]: cardId },
+      {
+        $unset: unset,
+        $pull: { [`columns.${columnId}.taskCards`]: cardId },
+      }
     )
 
-    return NextResponse.json({ status: 204 })
+    if (result.matchedCount === 0) {
+      return jsonError(404, 'Card not found')
+    }
+
+    return NextResponse.json({ deleted: cardId })
   }
 )

--- a/app/api/planner/columns/[columnId]/cards/reorder/route.ts
+++ b/app/api/planner/columns/[columnId]/cards/reorder/route.ts
@@ -1,22 +1,33 @@
-import { ExtendedNextRequest, Params, withMiddleware } from '@/lib/middleware'
+import { cardReorder, entityId } from '@/lib/apiSchemas'
+import { ExtendedNextRequest, Params, jsonError, parseBody, withMiddleware } from '@/lib/middleware'
 import Planner from '@/models/Planner'
 import { NextResponse } from 'next/server'
-
-interface ReorderCardsRequestBody {
-  reorderedCardIds: string[]
-}
 
 export const PATCH = withMiddleware(
   async (req: ExtendedNextRequest, { params }: { params: Params }): Promise<NextResponse> => {
     const { userId } = req
-    const { columnId } = params
-    const { reorderedCardIds }: ReorderCardsRequestBody = await req.json()
 
-    await Planner.updateOne(
+    const parsedColumnId = entityId.safeParse(params.columnId)
+    if (!parsedColumnId.success) {
+      return jsonError(400, 'Invalid column id')
+    }
+    const columnId = parsedColumnId.data
+
+    const body = await parseBody(req, cardReorder)
+    if (body.error) {
+      return body.error
+    }
+    const { reorderedCardIds } = body.data
+
+    const result = await Planner.updateOne(
       { clerkUserId: userId, [`columns.${columnId}.id`]: columnId },
       { $set: { [`columns.${columnId}.taskCards`]: reorderedCardIds } }
     )
 
-    return NextResponse.json({ status: 204 })
+    if (result.matchedCount === 0) {
+      return jsonError(404, 'Column not found')
+    }
+
+    return NextResponse.json({ ok: true }, { status: 200 })
   }
 )

--- a/app/api/planner/columns/[columnId]/cards/route.ts
+++ b/app/api/planner/columns/[columnId]/cards/route.ts
@@ -1,22 +1,38 @@
-// pages/api/planner/columns/[columnId]/cards/route.ts
-import { ExtendedNextRequest, Params, withMiddleware } from '@/lib/middleware'
+import { cardCreate, entityId } from '@/lib/apiSchemas'
+import { ExtendedNextRequest, Params, jsonError, parseBody, withMiddleware } from '@/lib/middleware'
 import Planner from '@/models/Planner'
 import { NextResponse } from 'next/server'
 
-export const POST = withMiddleware(async (req: ExtendedNextRequest, { params }: { params: Params }) => {
-  const { userId } = req
-  const { columnId } = params
-  const { newTaskCardDetails: newCard, updatedTaskCards } = await req.json()
+export const POST = withMiddleware(
+  async (req: ExtendedNextRequest, { params }: { params: Params }): Promise<NextResponse> => {
+    const { userId } = req
 
-  await Planner.updateOne(
-    { clerkUserId: userId },
-    {
-      $set: {
-        [`columns.${columnId}.taskCards`]: updatedTaskCards,
-        [`taskCards.${newCard.id}`]: newCard,
-      },
+    const parsedColumnId = entityId.safeParse(params.columnId)
+    if (!parsedColumnId.success) {
+      return jsonError(400, 'Invalid column id')
     }
-  )
+    const columnId = parsedColumnId.data
 
-  return NextResponse.json({ status: 201 })
-})
+    const body = await parseBody(req, cardCreate)
+    if (body.error) {
+      return body.error
+    }
+    const { newTaskCardDetails: newCard, updatedTaskCards } = body.data
+
+    const result = await Planner.updateOne(
+      { clerkUserId: userId, [`columns.${columnId}.id`]: columnId },
+      {
+        $set: {
+          [`columns.${columnId}.taskCards`]: updatedTaskCards,
+          [`taskCards.${newCard.id}`]: newCard,
+        },
+      }
+    )
+
+    if (result.matchedCount === 0) {
+      return jsonError(404, 'Column not found')
+    }
+
+    return NextResponse.json({ cardId: newCard.id }, { status: 201 })
+  }
+)

--- a/app/api/planner/columns/[columnId]/route.ts
+++ b/app/api/planner/columns/[columnId]/route.ts
@@ -1,27 +1,33 @@
-// pages/api/planner/columns/[columnId]/name/route.ts
-import { ExtendedNextRequest, Params, withMiddleware } from '@/lib/middleware'
+import { columnPatch, entityId } from '@/lib/apiSchemas'
+import { ExtendedNextRequest, Params, jsonError, parseBody, withMiddleware } from '@/lib/middleware'
 import Planner from '@/models/Planner'
 import { NextResponse } from 'next/server'
-
-interface ChangeColumnNameRequestBody {
-  newName: string
-}
 
 export const PATCH = withMiddleware(
   async (req: ExtendedNextRequest, { params }: { params: Params }): Promise<NextResponse> => {
     const { userId } = req
-    const { columnId } = params
-    const { newName }: ChangeColumnNameRequestBody = await req.json()
 
-    await Planner.updateOne(
-      { clerkUserId: userId },
-      {
-        $set: {
-          [`columns.${columnId}.name`]: newName,
-        },
-      }
+    const parsedColumnId = entityId.safeParse(params.columnId)
+    if (!parsedColumnId.success) {
+      return jsonError(400, 'Invalid column id')
+    }
+    const columnId = parsedColumnId.data
+
+    const body = await parseBody(req, columnPatch)
+    if (body.error) {
+      return body.error
+    }
+    const { newName } = body.data
+
+    const result = await Planner.updateOne(
+      { clerkUserId: userId, [`columns.${columnId}.id`]: columnId },
+      { $set: { [`columns.${columnId}.name`]: newName } }
     )
 
-    return NextResponse.json({})
+    if (result.matchedCount === 0) {
+      return jsonError(404, 'Column not found')
+    }
+
+    return NextResponse.json({ ok: true }, { status: 200 })
   }
 )

--- a/app/api/planner/route.ts
+++ b/app/api/planner/route.ts
@@ -1,51 +1,63 @@
-import { TaskCardInfoType } from '@/hooks/Planner/types'
 import { ExtendedNextRequest, withMiddleware } from '@/lib/middleware'
 import Planner from '@/models/Planner'
 import { NextResponse } from 'next/server'
 
 export const GET = withMiddleware(async (req: ExtendedNextRequest) => {
   const { userId } = req
-  let user = await Planner.findOne({ clerkUserId: userId }).lean()
 
-  if (!user) {
-    user = new Planner({
-      clerkUserId: userId,
-      boardOrder: [],
-      boards: {},
-      columns: {},
-      categories: {},
-      taskCards: {},
-      subTasks: {},
-    })
-    await user.save()
-    user = user.toObject()
-  } else {
-    // Update task cards with status 'completed' to 'archived'. This is because the task cards are
-    // shown in the UI whenever they're completed, but on subsequent API calls, they should not be shown.
-    // These cards will only be shown in the archive section.
-    const updatedTaskCards = { ...user.taskCards }
-    const updatedColumns = { ...user.columns }
+  // Race-proof get-or-create: the unique index on clerkUserId guarantees that
+  // concurrent first loads converge on a single document.
+  const user = await Planner.findOneAndUpdate(
+    { clerkUserId: userId },
+    {
+      $setOnInsert: {
+        clerkUserId: userId,
+        boardOrder: [],
+        boards: {},
+        columns: {},
+        categories: {},
+        taskCards: {},
+        subTasks: {},
+      },
+    },
+    { upsert: true, new: true }
+  ).lean()
 
-    for (const taskId in updatedTaskCards) {
-      if (updatedTaskCards[taskId].status === 'completed') {
-        updatedTaskCards[taskId].status = 'archived'
-        // Remove archived task cards from their columns
-        for (const columnId in updatedColumns) {
-          const column = updatedColumns[columnId]
-          const taskIndex = column.taskCards.indexOf(taskId)
-          if (taskIndex > -1) {
-            column.taskCards.splice(taskIndex, 1)
-          }
-        }
+  // Cards completed since the last fetch get archived: they were shown in the UI
+  // when completed, but on subsequent loads they only appear in the archive section.
+  const archivedIds = Object.keys(user.taskCards).filter((taskId) => user.taskCards[taskId].status === 'completed')
+
+  if (archivedIds.length > 0) {
+    const set: Record<string, string> = {}
+    const pull: Record<string, { $in: string[] }> = {}
+
+    for (const taskId of archivedIds) {
+      set[`taskCards.${taskId}.status`] = 'archived'
+      user.taskCards[taskId].status = 'archived'
+    }
+
+    for (const columnId in user.columns) {
+      const column = user.columns[columnId]
+      const remaining = column.taskCards.filter((taskId) => !archivedIds.includes(taskId))
+      if (remaining.length !== column.taskCards.length) {
+        pull[`columns.${columnId}.taskCards`] = { $in: archivedIds }
+        column.taskCards = remaining
       }
     }
-    await Planner.updateOne({ clerkUserId: userId }, { taskCards: updatedTaskCards, columns: updatedColumns })
 
-    // Filter task cards to only return those with status 'created'
-    user.taskCards = Object.fromEntries(
-      Object.entries(updatedTaskCards).filter(([_, taskCard]) => (taskCard as TaskCardInfoType).status === 'created')
+    // Targeted paths only — never overwrite whole maps, so concurrent writes
+    // to other cards/columns are preserved.
+    await Planner.updateOne(
+      { clerkUserId: userId },
+      Object.keys(pull).length > 0 ? { $set: set, $pull: pull } : { $set: set }
     )
   }
+
+  // Only 'created' cards are returned; 'archived' ones stay in the document
+  // for the future archive view to read.
+  user.taskCards = Object.fromEntries(
+    Object.entries(user.taskCards).filter(([, taskCard]) => taskCard.status === 'created')
+  )
 
   return NextResponse.json(user)
 })

--- a/app/api/planner/subtasks/[subTaskId]/route.ts
+++ b/app/api/planner/subtasks/[subTaskId]/route.ts
@@ -1,28 +1,41 @@
-import { ExtendedNextRequest, Params, withMiddleware } from '@/lib/middleware'
+import { entityId, subTaskPatch } from '@/lib/apiSchemas'
+import { ExtendedNextRequest, Params, jsonError, parseBody, withMiddleware } from '@/lib/middleware'
 import Planner from '@/models/Planner'
 import { NextResponse } from 'next/server'
-
-interface SubTaskModificationRequestBody {
-  title?: string
-  checked?: boolean
-}
 
 export const PATCH = withMiddleware(
   async (req: ExtendedNextRequest, { params }: { params: Params }): Promise<NextResponse> => {
     const { userId } = req
-    const { subTaskId } = params
-    const body: SubTaskModificationRequestBody = await req.json()
 
-    const [key, value] = Object.entries(body)[0]
-    const updateField = { [`subTasks.${subTaskId}.${key}`]: value }
+    const parsedSubTaskId = entityId.safeParse(params.subTaskId)
+    if (!parsedSubTaskId.success) {
+      return jsonError(400, 'Invalid subtask id')
+    }
+    const subTaskId = parsedSubTaskId.data
 
-    await Planner.updateOne(
-      { clerkUserId: userId },
-      {
-        $set: updateField,
-      }
+    const body = await parseBody(req, subTaskPatch)
+    if (body.error) {
+      return body.error
+    }
+
+    // Build the update from the validated fields only — never from raw body keys.
+    const updateFields: Record<string, string | boolean> = {}
+    if (body.data.title !== undefined) {
+      updateFields[`subTasks.${subTaskId}.title`] = body.data.title
+    }
+    if (body.data.checked !== undefined) {
+      updateFields[`subTasks.${subTaskId}.checked`] = body.data.checked
+    }
+
+    const result = await Planner.updateOne(
+      { clerkUserId: userId, [`subTasks.${subTaskId}.id`]: subTaskId },
+      { $set: updateFields }
     )
 
-    return NextResponse.json({ status: 204 })
+    if (result.matchedCount === 0) {
+      return jsonError(404, 'Subtask not found')
+    }
+
+    return NextResponse.json({ ok: true })
   }
 )

--- a/lib/apiSchemas.ts
+++ b/lib/apiSchemas.ts
@@ -1,0 +1,170 @@
+import { UNASSIGNED_CATEGORY_ID } from '@/constants/constants'
+import { z } from 'zod'
+
+/*
+ * Single source of truth for API request validation. Every schema mirrors the
+ * exact payload the client mutation utils send today (utils/plannerUtils/**),
+ * with .strict() so unknown keys are rejected instead of mass-assigned into
+ * dotted $set paths.
+ */
+
+// Client-minted ids come from NANOID in constants/constants.ts: 17 chars, 0-9a-z.
+export const entityId = z.string().regex(/^[0-9a-z]{17}$/, 'must be a 17-character lowercase alphanumeric id')
+
+// The per-board default category uses the literal id 'unassigned'.
+export const categoryId = z.union([entityId, z.literal(UNASSIGNED_CATEGORY_ID)])
+
+const name = z.string().min(1).max(200)
+const cardTitle = z.string().max(500) // cards/subtasks may legitimately have empty titles while being typed
+const cardContent = z.string().max(50000)
+const color = z.string().min(1).max(50)
+const cardStatus = z.enum(['created', 'completed', 'archived'])
+
+const categoryDetails = z
+  .object({
+    id: categoryId,
+    name,
+    color,
+  })
+  .strict()
+
+// POST /api/planner/boards — addNewBoardToPlanner.ts
+export const boardCreate = z
+  .object({
+    boardId: entityId,
+    boardName: name,
+    unassignedCategoryDetails: categoryDetails,
+  })
+  .strict()
+
+// PATCH /api/planner/boards/[boardId] — changeBoardInfo.ts
+export const boardPatch = z
+  .object({
+    newName: name,
+  })
+  .strict()
+
+// POST /api/planner/boards/[boardId]/columns — addNewColumn.ts
+export const columnCreate = z
+  .object({
+    newColumnDetails: z
+      .object({
+        id: entityId,
+        name,
+        taskCards: z.array(entityId),
+      })
+      .strict(),
+    updatedColumns: z.array(entityId),
+  })
+  .strict()
+
+// PATCH /api/planner/boards/[boardId]/columns/reorder — changeColumnOrder.ts
+export const columnReorder = z
+  .object({
+    newColumnOrder: z.array(entityId),
+  })
+  .strict()
+
+// PATCH /api/planner/columns/[columnId] — changeColumnName.ts
+export const columnPatch = z
+  .object({
+    newName: name,
+  })
+  .strict()
+
+// POST /api/planner/boards/[boardId]/categories — addNewCategory.ts
+export const categoryCreate = z
+  .object({
+    newCategoryDetails: categoryDetails,
+  })
+  .strict()
+
+// PATCH /api/planner/categories/[categoryId] — changeCategoryInfo.ts
+export const categoryPatch = z
+  .object({
+    newName: name,
+    newColor: color,
+  })
+  .strict()
+
+// POST /api/planner/columns/[columnId]/cards — addNewCardToColumn.ts
+export const cardCreate = z
+  .object({
+    newTaskCardDetails: z
+      .object({
+        id: entityId,
+        title: cardTitle,
+        category: categoryId,
+        content: cardContent,
+        status: z.literal('created'),
+        subTasks: z.array(entityId),
+      })
+      .strict(),
+    updatedTaskCards: z.array(entityId),
+  })
+  .strict()
+
+// PATCH /api/planner/cards/[cardId] — changeCardTitle/Content/Category/CheckedStatus.ts
+// columnId + taskCardOrder travel together so the check-completes-card flow can
+// persist the column reorder it already performs client-side.
+export const cardPatch = z
+  .object({
+    title: cardTitle.optional(),
+    content: cardContent.optional(),
+    status: cardStatus.optional(),
+    category: categoryId.optional(),
+    columnId: entityId.optional(),
+    taskCardOrder: z.array(entityId).optional(),
+  })
+  .strict()
+  .refine((body) => Object.keys(body).length > 0, { message: 'at least one field is required' })
+  .refine((body) => (body.columnId === undefined) === (body.taskCardOrder === undefined), {
+    message: 'columnId and taskCardOrder must be provided together',
+  })
+
+// PATCH /api/planner/cards/[cardId]/move — moveCardAcrossColumns.ts
+export const cardMove = z
+  .object({
+    sourceColumnId: entityId,
+    destColumnId: entityId,
+    sourceColumnTaskCardIds: z.array(entityId),
+    destColumnTaskCardIds: z.array(entityId),
+  })
+  .strict()
+
+// PATCH /api/planner/columns/[columnId]/cards/reorder — moveCardWithinColumn.ts
+export const cardReorder = z
+  .object({
+    reorderedCardIds: z.array(entityId),
+  })
+  .strict()
+
+// POST /api/planner/cards/[cardId]/subtasks — addNewSubTaskToCard.ts
+export const subTaskCreate = z
+  .object({
+    newSubTaskDetails: z
+      .object({
+        id: entityId,
+        title: cardTitle,
+        checked: z.boolean(),
+      })
+      .strict(),
+    newSubTasksOrder: z.array(entityId),
+  })
+  .strict()
+
+// PATCH /api/planner/subtasks/[subTaskId] — changeSubTaskTitle/CheckedStatus.ts
+export const subTaskPatch = z
+  .object({
+    title: cardTitle.optional(),
+    checked: z.boolean().optional(),
+  })
+  .strict()
+  .refine((body) => Object.keys(body).length > 0, { message: 'at least one field is required' })
+
+// PATCH /api/planner/cards/[cardId]/subtasks/move — reorderSubtasks.ts
+export const subTaskReorder = z
+  .object({
+    reorderedSubTasks: z.array(entityId),
+  })
+  .strict()

--- a/lib/dbConnect.ts
+++ b/lib/dbConnect.ts
@@ -1,11 +1,5 @@
 import mongoose, { Mongoose } from 'mongoose'
 
-const MONGO_URI: string | undefined = process.env.MONGO_URI
-
-if (!MONGO_URI) {
-  throw new Error('Please define the MONGO_URI environment variable')
-}
-
 interface CachedType {
   conn: Mongoose | null
   promise: Promise<Mongoose> | null
@@ -24,6 +18,13 @@ if (!cached) {
 }
 
 async function dbConnect(): Promise<Mongoose> {
+  // Checked at connect time, not import time, so `next build` can collect
+  // page data without a database configured.
+  const MONGO_URI = process.env.MONGO_URI
+  if (!MONGO_URI) {
+    throw new Error('Please define the MONGO_URI environment variable')
+  }
+
   if (cached.conn) {
     return cached.conn
   }
@@ -33,7 +34,7 @@ async function dbConnect(): Promise<Mongoose> {
       bufferCommands: false,
     }
 
-    cached.promise = mongoose.connect(MONGO_URI!, opts).then((mongoose) => {
+    cached.promise = mongoose.connect(MONGO_URI, opts).then((mongoose) => {
       return mongoose
     })
   }

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -1,7 +1,8 @@
-// utils/middleware.ts
 import dbConnect from '@/lib/dbConnect'
 import { auth } from '@clerk/nextjs/server'
+import mongoose from 'mongoose'
 import { NextRequest, NextResponse } from 'next/server'
+import { ZodSchema } from 'zod'
 
 export interface ExtendedNextRequest extends NextRequest {
   userId?: string
@@ -21,33 +22,65 @@ export interface ExtendedNextContext {
 
 type Handler = (req: ExtendedNextRequest, context: ExtendedNextContext) => Promise<NextResponse>
 
+export function jsonError(status: number, error: string): NextResponse {
+  return NextResponse.json({ error }, { status })
+}
+
+/*
+ * Parses and validates a request body against a zod schema. Returns either the
+ * typed data or a ready-to-return 400 response (covers malformed/empty JSON too,
+ * which used to escape the error handler entirely as an unawaited rejection).
+ */
+export async function parseBody<T>(
+  req: NextRequest,
+  schema: ZodSchema<T>
+): Promise<{ data: T; error?: never } | { data?: never; error: NextResponse }> {
+  let raw: unknown
+  try {
+    raw = await req.json()
+  } catch {
+    return { error: jsonError(400, 'Request body must be valid JSON') }
+  }
+  const parsed = schema.safeParse(raw)
+  if (!parsed.success) {
+    const issues = parsed.error.issues.map((issue) => `${issue.path.join('.') || 'body'}: ${issue.message}`)
+    return { error: jsonError(400, `Invalid request body — ${issues.join('; ')}`) }
+  }
+  return { data: parsed.data }
+}
+
 export function withDbConnect(handler: Handler): Handler {
   return async (req, context) => {
-    try {
-      await dbConnect()
-      return handler(req, context)
-    } catch (error) {
-      return NextResponse.json({ status: 500, error: 'Internal Server Error' })
-    }
+    await dbConnect()
+    return await handler(req, context)
   }
 }
 
 export function withAuth(handler: Handler): Handler {
   return async (req, context) => {
+    const { userId } = auth()
+    if (!userId) {
+      return jsonError(401, 'Unauthorized')
+    }
+    req.userId = userId
+    return await handler(req, context)
+  }
+}
+
+export function withErrorHandling(handler: Handler): Handler {
+  return async (req, context) => {
     try {
-      const authObj = auth()
-      const { userId } = authObj
-      if (!userId) {
-        return NextResponse.json({ status: 401, error: 'Unauthorized' })
-      }
-      req.userId = userId
-      return handler(req, context)
+      return await handler(req, context)
     } catch (error) {
-      return NextResponse.json({ status: 500, error: 'Internal Server Error' })
+      if (error instanceof mongoose.Error.ValidationError) {
+        return jsonError(400, 'Validation failed')
+      }
+      console.error(`[api] ${req.method} ${req.nextUrl.pathname}:`, error)
+      return jsonError(500, 'Internal server error')
     }
   }
 }
 
 export function withMiddleware(handler: Handler): Handler {
-  return withAuth(withDbConnect(handler))
+  return withErrorHandling(withAuth(withDbConnect(handler)))
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,5 +7,10 @@ export default clerkMiddleware((auth, req) => {
 })
 
 export const config = {
-  matcher: ['/((?!.*\\..*|_next).*)', '/', '/(api|trpc)(.*)'],
+  // Skip Next.js internals and static assets by extension instead of excluding
+  // every path containing a dot (which let dotted routes bypass Clerk entirely).
+  matcher: [
+    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+    '/(api|trpc)(.*)',
+  ],
 }

--- a/models/Planner.ts
+++ b/models/Planner.ts
@@ -1,10 +1,9 @@
-const mongoose = require('mongoose')
-const { Schema } = mongoose
+import mongoose, { InferSchemaType, Model, Schema } from 'mongoose'
 
 const subTaskSchema = new Schema(
   {
     id: { type: String, required: true },
-    title: { type: String, required: true },
+    title: { type: String, default: '' },
     checked: { type: Boolean, default: false },
   },
   { _id: false }
@@ -13,10 +12,10 @@ const subTaskSchema = new Schema(
 const taskCardSchema = new Schema(
   {
     id: { type: String, required: true },
-    title: { type: String, required: true },
+    title: { type: String, default: '' },
     category: { type: String, required: true },
-    content: { type: String },
-    status: { type: String, required: true },
+    content: { type: String, default: '' },
+    status: { type: String, required: true, enum: ['created', 'completed', 'archived'] },
     subTasks: [String],
   },
   { _id: false }
@@ -52,7 +51,8 @@ const categorySchema = new Schema(
 
 const plannerSchema = new Schema(
   {
-    clerkUserId: { type: String, required: true },
+    // The tenancy key for every query in the app — unique creates the index.
+    clerkUserId: { type: String, required: true, unique: true },
     boardOrder: [String],
     boards: { type: Map, of: boardSchema, default: {} },
     columns: { type: Map, of: columnSchema, default: {} },
@@ -60,7 +60,12 @@ const plannerSchema = new Schema(
     taskCards: { type: Map, of: taskCardSchema, default: {} },
     subTasks: { type: Map, of: subTaskSchema, default: {} },
   },
-  { minimize: false }
+  { minimize: false, timestamps: true }
 )
 
-export default mongoose.models.Planner || mongoose.model('Planner', plannerSchema, 'planner')
+export type PlannerDoc = InferSchemaType<typeof plannerSchema>
+
+const Planner: Model<PlannerDoc> =
+  (mongoose.models.Planner as Model<PlannerDoc>) || mongoose.model<PlannerDoc>('Planner', plannerSchema, 'planner')
+
+export default Planner

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,19 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: false,
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains' },
+        ],
+      },
+    ]
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
Phase 2 of the post-dossier revitalization. Kills three of the six critical findings:

- **Every API response was HTTP 200** — including auth failures and server errors (status lived in the response body). Now real status codes: 200/201/400/401/404/500.
- **The error-handling layer was dead code** — `return handler(...)` without `await` let every rejection escape the only try/catch. Now properly awaited with central error handling.
- **`Object.entries(body)[0]`** — PATCH routes applied only the first body key, threw on `{}`, and spliced arbitrary keys into `$set` paths. Now zod-validated bodies (`.strict()`), explicit allowlists, validated path params.

Plus the major backend findings: cascade deletes (one atomic update each, sparing the shared `unassigned` category), race-proof upsert on first GET, non-destructive GET (targeted archive writes only when needed — no more blind whole-map overwrites that clobbered concurrent edits), unique index on `clerkUserId`, typed ESM mongoose model, `updateMany` eradicated, matchedCount → 404, build no longer requires a DB, Clerk matcher dot-bypass fixed, security headers.

Contract note: PATCH `/cards/[cardId]` now accepts optional `columnId`+`taskCardOrder` so the phase-3 client can persist the check-a-card reorder that currently diverges on reload.

Verification: tsc clean, lint clean, production build passes. Every schema was derived from the actual payload its client util sends today — current client keeps working unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)