### PR TITLE
Client data layer: visible failures, ordered writes, per-entity debounce

### DIFF
--- a/components/planner/Board/TaskColumns/AddNewColumnButton.tsx
+++ b/components/planner/Board/TaskColumns/AddNewColumnButton.tsx
@@ -3,7 +3,6 @@ import { Form, FormControl, FormField, FormItem, FormMessage } from '@/component
 import { Input } from '@/components/ui/input'
 import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
 import { addNewColumn } from '@/utils/plannerUtils/columnUtils/addNewColumn'
-import { useAuth } from '@clerk/nextjs'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Dispatch, SetStateAction, useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -16,7 +15,6 @@ type AddNewColumnFormProps = {
 }
 
 const AddNewColumnForm = ({ boardId, setIsAddingColumn }: AddNewColumnFormProps) => {
-  const { getToken } = useAuth()
   const dispatch = usePlannerDispatch()!
   const { boards } = usePlanner()
 
@@ -34,7 +32,7 @@ const AddNewColumnForm = ({ boardId, setIsAddingColumn }: AddNewColumnFormProps)
   })
 
   const onSubmit = (values: z.infer<typeof formSchema>) => {
-    addNewColumn(boards[boardId], values.columnName, dispatch, getToken)
+    addNewColumn(boards[boardId], values.columnName, dispatch)
     setIsAddingColumn(false)
   }
 

--- a/components/planner/Board/TaskColumns/TaskCard/CategoryBadge.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/CategoryBadge.tsx
@@ -7,7 +7,6 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
 import changeCardCategory from '@/utils/plannerUtils/cardUtils/changeCardCategory'
-import { useAuth } from '@clerk/nextjs'
 import { badgeClassNames, badgeClassNamesWithoutHover } from './utils'
 
 type CategoryBadgeProps = {
@@ -16,7 +15,6 @@ type CategoryBadgeProps = {
 }
 
 export const CategoryBadge = ({ boardId, taskCardId }: CategoryBadgeProps) => {
-  const { getToken } = useAuth()
   const dispatch = usePlannerDispatch()!
   const { boards, taskCards, categories } = usePlanner()
   const categoryInfo = categories[taskCards[taskCardId].category]
@@ -34,7 +32,7 @@ export const CategoryBadge = ({ boardId, taskCardId }: CategoryBadgeProps) => {
             checked={categoryInfo.name === categories[categoryId].name}
             onClick={(event) => {
               event.preventDefault()
-              changeCardCategory(taskCardId, categoryId, dispatch, getToken)
+              changeCardCategory(taskCardId, categoryId, dispatch)
             }}
           >
             <Badge variant='defaultNoHover' className={badgeClassNamesWithoutHover[categories[categoryId].color]}>

--- a/components/planner/Board/TaskColumns/TaskCard/InitializingTaskCard/InitializingTaskCard.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/InitializingTaskCard/InitializingTaskCard.tsx
@@ -7,7 +7,6 @@ import { UNASSIGNED_CATEGORY_ID } from '@/constants/constants'
 import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
 import { cn } from '@/lib/utils'
 import { addNewCardToColumn } from '@/utils/plannerUtils/cardUtils/addNewCardToColumn'
-import { useAuth } from '@clerk/nextjs'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -29,7 +28,6 @@ const formSchema = z.object({
 })
 
 export const InitializingTaskCard = ({ boardId, columnId }: InitializingTaskCardProps) => {
-  const { getToken } = useAuth()
   const dispatch = usePlannerDispatch()
   const { columns, taskCardBeingInitialized } = usePlanner()
   const [selectedCategory, setSelectedCategory] = useState(UNASSIGNED_CATEGORY_ID)
@@ -64,7 +62,7 @@ export const InitializingTaskCard = ({ boardId, columnId }: InitializingTaskCard
       category: selectedCategory,
       content: values.taskCardDesc,
     }
-    addNewCardToColumn(columns[columnId], newTaskCardDetails, dispatch, getToken)
+    addNewCardToColumn(columns[columnId], newTaskCardDetails, dispatch)
     toast.success('Task added.')
   }
 

--- a/components/planner/Board/TaskColumns/TaskCard/SubTasks.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/SubTasks.tsx
@@ -1,14 +1,12 @@
 import { Checkbox } from '@/components/ui/checkbox'
 import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
 import changeSubTaskCheckedStatus from '@/utils/plannerUtils/subTaskUtils/changeSubTaskCheckedStatus'
-import { useAuth } from '@clerk/nextjs'
 
 type SubTasksProps = {
   taskCardId: string
 }
 
 export const SubTasks = ({ taskCardId }: SubTasksProps) => {
-  const { getToken } = useAuth()
   const dispatch = usePlannerDispatch()
   const { taskCards, subTasks } = usePlanner()
   const subTasksUnderTaskCard = taskCards[taskCardId].subTasks.map((subTaskId) => subTasks[subTaskId])
@@ -24,7 +22,7 @@ export const SubTasks = ({ taskCardId }: SubTasksProps) => {
               if (isEditable) {
                 event.preventDefault() // Neede to prevent dialog from triggering
                 const isChecked = (event.target as HTMLButtonElement).getAttribute('data-state') === 'checked'
-                changeSubTaskCheckedStatus(subTask.id, !isChecked, dispatch, getToken)
+                changeSubTaskCheckedStatus(subTask.id, !isChecked, dispatch)
               }
             }}
           />

--- a/components/planner/Board/TaskColumns/TaskCard/TaskCard.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/TaskCard.tsx
@@ -5,7 +5,6 @@ import { Dialog, DialogTrigger } from '@/components/ui/dialog'
 import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
 import { cn } from '@/lib/utils'
 import changeCardCheckedStatus from '@/utils/plannerUtils/cardUtils/changeCardCheckedStatus'
-import { useAuth } from '@clerk/nextjs'
 import { Draggable } from '@hello-pangea/dnd'
 import { toast } from 'sonner'
 import { CategoryBadge } from './CategoryBadge'
@@ -55,9 +54,8 @@ export const TaskCard = ({ index, boardId, columnId, taskCardId }: TaskCardProps
   // was in the wrapper component. There was no straightforward way to pass that info down to it's children (i.e. TaskCard).
   // Using ContextProvider is possible but was way too convoluted- i.e. the isDragging property wouldn't cause re-renders,
   // and thus the card wouldn't turn transparent, which is the reason why we need to know if the card is being dragged.
-  const { getToken } = useAuth()
   const dispatch = usePlannerDispatch()
-  const { taskCards, idOfCardBeingDragged } = usePlanner()
+  const { taskCards, columns, idOfCardBeingDragged } = usePlanner()
   const task = taskCards[taskCardId]
 
   return (
@@ -93,7 +91,7 @@ export const TaskCard = ({ index, boardId, columnId, taskCardId }: TaskCardProps
                 } else {
                   toast.info('Task marked as incomplete.')
                 }
-                changeCardCheckedStatus(columnId, taskCardId, !isChecked, dispatch, getToken)
+                changeCardCheckedStatus(columnId, taskCardId, !isChecked, columns[columnId].taskCards, dispatch)
               }}
             />
           </div>

--- a/components/planner/Board/TaskColumns/TaskCard/TaskCardContextMenu/ContextMenuWrapper.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/TaskCardContextMenu/ContextMenuWrapper.tsx
@@ -10,8 +10,6 @@ import {
 } from '@/components/ui/alert-dialog'
 import { usePlannerDispatch } from '@/hooks/Planner/Planner'
 import deleteCard from '@/utils/plannerUtils/cardUtils/deleteCard'
-import { useAuth } from '@clerk/nextjs'
-import { useErrorBoundary } from 'react-error-boundary'
 
 type ContextMenuWrapperProps = {
   columnId: string
@@ -20,9 +18,7 @@ type ContextMenuWrapperProps = {
 }
 
 export const ContextMenuWrapper = ({ columnId, taskCardId, children }: ContextMenuWrapperProps) => {
-  const { getToken } = useAuth()
   const dispatch = usePlannerDispatch()
-  const { showBoundary } = useErrorBoundary()
   return (
     <AlertDialog>
       {children}
@@ -35,7 +31,7 @@ export const ContextMenuWrapper = ({ columnId, taskCardId, children }: ContextMe
           <AlertDialogCancel>Cancel</AlertDialogCancel>
           <AlertDialogAction
             onClick={() => {
-              deleteCard(columnId, taskCardId, dispatch, getToken)
+              deleteCard(columnId, taskCardId, dispatch)
             }}
           >
             Continue

--- a/components/planner/Board/TaskColumns/TaskCard/TaskCardContextMenu/MoveToBottomContextMenuItem.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/TaskCardContextMenu/MoveToBottomContextMenuItem.tsx
@@ -1,13 +1,11 @@
 import { ContextMenuItem } from '@/components/ui/context-menu'
 import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
 import moveCardWithinColumn from '@/utils/plannerUtils/cardUtils/moveCardWithinColumn'
-import { useAuth } from '@clerk/nextjs'
 import { ArrowBigDown } from 'lucide-react'
 import { useContext } from 'react'
 import { ContextMenuItemContext } from './TaskCardContextMenu'
 
 export const MoveToBottomContextMenuItem = () => {
-  const { getToken } = useAuth()
   const dispatch = usePlannerDispatch()
   const { columns } = usePlanner()
   const { columnId, taskCardId, iconProps, contextMenuItemProps } = useContext(ContextMenuItemContext)!
@@ -17,7 +15,7 @@ export const MoveToBottomContextMenuItem = () => {
     <ContextMenuItem disabled={index === lastIndex}>
       <div
         {...contextMenuItemProps}
-        onClick={() => moveCardWithinColumn(columns, columnId, taskCardId, index, lastIndex, dispatch, getToken)}
+        onClick={() => moveCardWithinColumn(columns, columnId, taskCardId, index, lastIndex, dispatch)}
       >
         <ArrowBigDown {...iconProps} />
         <span>Move to bottom</span>

--- a/components/planner/Board/TaskColumns/TaskCard/TaskCardContextMenu/MoveToTopContextMenuItem.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/TaskCardContextMenu/MoveToTopContextMenuItem.tsx
@@ -1,13 +1,11 @@
 import { ContextMenuItem } from '@/components/ui/context-menu'
 import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
 import moveCardWithinColumn from '@/utils/plannerUtils/cardUtils/moveCardWithinColumn'
-import { useAuth } from '@clerk/nextjs'
 import { ArrowBigUp } from 'lucide-react'
 import { useContext } from 'react'
 import { ContextMenuItemContext } from './TaskCardContextMenu'
 
 export const MoveToTopContextMenuItem = () => {
-  const { getToken } = useAuth()
   const dispatch = usePlannerDispatch()
   const { columns } = usePlanner()
   const { columnId, taskCardId, iconProps, contextMenuItemProps } = useContext(ContextMenuItemContext)!
@@ -16,7 +14,7 @@ export const MoveToTopContextMenuItem = () => {
     <ContextMenuItem disabled={index === 0}>
       <div
         {...contextMenuItemProps}
-        onClick={() => moveCardWithinColumn(columns, columnId, taskCardId, index, 0, dispatch, getToken)}
+        onClick={() => moveCardWithinColumn(columns, columnId, taskCardId, index, 0, dispatch)}
       >
         <ArrowBigUp {...iconProps} />
         <span>Move to top</span>

--- a/components/planner/Board/TaskColumns/TaskCard/TaskCardDialog/AddNewSubTaskButton.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/TaskCardDialog/AddNewSubTaskButton.tsx
@@ -1,6 +1,5 @@
 import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
 import { addNewSubTaskOnButtonClick } from '@/utils/plannerUtils/subTaskUtils/addNewSubTaskToCard'
-import { useAuth } from '@clerk/nextjs'
 import { GripVertical, PlusCircle } from 'lucide-react'
 import { useState } from 'react'
 
@@ -12,14 +11,13 @@ export const AddNewSubTaskButton = ({ taskCardId }: AddNewSubTaskButtonProps) =>
   const dispatch = usePlannerDispatch()
   const [isHoveringOver, setIsHoveringOver] = useState(false)
   const { taskCards, isSubTaskBeingDragged } = usePlanner()
-  const { getToken } = useAuth()
 
   return (
     <div
       className='flex items-center gap-2 mt-1 hover:cursor-pointer'
       onMouseEnter={() => setIsHoveringOver(true)}
       onMouseLeave={() => setIsHoveringOver(false)}
-      onClick={() => addNewSubTaskOnButtonClick(taskCards[taskCardId], dispatch, getToken)}
+      onClick={() => addNewSubTaskOnButtonClick(taskCards[taskCardId], dispatch)}
     >
       <GripVertical size={12} className='invisible' />
       <PlusCircle

--- a/components/planner/Board/TaskColumns/TaskCard/TaskCardDialog/EditableSubTasks/EditableSubTask.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/TaskCardDialog/EditableSubTasks/EditableSubTask.tsx
@@ -4,7 +4,6 @@ import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
 import { SubTaskInfoType } from '@/hooks/Planner/types'
 import changeSubTaskCheckedStatus from '@/utils/plannerUtils/subTaskUtils/changeSubTaskCheckedStatus'
 import changeSubTaskTitle from '@/utils/plannerUtils/subTaskUtils/changeSubTaskTitle'
-import { useAuth } from '@clerk/nextjs'
 import { DraggableProvided } from '@hello-pangea/dnd'
 import { GripVertical } from 'lucide-react'
 import { useState } from 'react'
@@ -22,7 +21,6 @@ export const EditableSubTask = ({ index, provided, taskCardId, subTask, isBeingD
   const { isSubTaskBeingDragged, taskCards, subTasks } = usePlanner()
   const [showDragHandle, setShowDragHandle] = useState(isSubTaskBeingDragged)
   const dispatch = usePlannerDispatch()!
-  const { getToken } = useAuth()
   return (
     <div
       ref={provided.innerRef}
@@ -43,7 +41,7 @@ export const EditableSubTask = ({ index, provided, taskCardId, subTask, isBeingD
       <Checkbox
         id={`${index}`}
         checked={subTask.checked}
-        onCheckedChange={(isChecked) => changeSubTaskCheckedStatus(subTask.id, Boolean(isChecked), dispatch, getToken)}
+        onCheckedChange={(isChecked) => changeSubTaskCheckedStatus(subTask.id, Boolean(isChecked), dispatch)}
       />
       <Input
         autoFocus
@@ -51,10 +49,8 @@ export const EditableSubTask = ({ index, provided, taskCardId, subTask, isBeingD
         type='text'
         value={subTask.title}
         className='my-1 px-1 border-none h-1 text-gray-500 text-sm focus-visible:ring-0 focus-visible:ring-transparent'
-        onKeyDown={(event) =>
-          handleKeyDownOnSubTask(taskCards, subTasks, taskCardId, subTask, event, dispatch, getToken)
-        }
-        onChange={(event) => changeSubTaskTitle(subTask.id, event.target.value, dispatch, getToken)}
+        onKeyDown={(event) => handleKeyDownOnSubTask(taskCards, subTasks, taskCardId, subTask, event, dispatch)}
+        onChange={(event) => changeSubTaskTitle(subTask.id, event.target.value, dispatch)}
       />
     </div>
   )

--- a/components/planner/Board/TaskColumns/TaskCard/TaskCardDialog/EditableSubTasks/types.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/TaskCardDialog/EditableSubTasks/types.tsx
@@ -12,8 +12,7 @@ export type HandleKeyDownOnSubTaskFunc = (
   taskCardId: string,
   subTask: SubTaskInfoType,
   event: React.KeyboardEvent<HTMLInputElement>,
-  dispatch: PlannerDispatchContextType,
-  getToken: () => Promise<string | null>
+  dispatch: PlannerDispatchContextType
 ) => void
 
 export type HandleArrowDownFunc = (taskCards: TaskCardsType, taskCardId: string, subTask: SubTaskInfoType) => void
@@ -24,14 +23,12 @@ export type HandleBackspaceFunc = (
   taskCard: TaskCardInfoType,
   subTaskId: string,
   event: React.KeyboardEvent<HTMLInputElement>,
-  dispatch: PlannerDispatchContextType,
-  getToken: () => Promise<string | null>
+  dispatch: PlannerDispatchContextType
 ) => void
 
 export type HandleEnterFunc = (
   taskCards: TaskCardsType,
   taskCardId: string,
   subTask: SubTaskInfoType,
-  dispatch: PlannerDispatchContextType,
-  getToken: () => Promise<string | null>
+  dispatch: PlannerDispatchContextType
 ) => void

--- a/components/planner/Board/TaskColumns/TaskCard/TaskCardDialog/EditableSubTasks/utils.ts
+++ b/components/planner/Board/TaskColumns/TaskCard/TaskCardDialog/EditableSubTasks/utils.ts
@@ -26,13 +26,13 @@ const handleArrowUp: HandleArrowUpFunc = (taskCards, taskCardId, subTask) => {
   }
 }
 
-const handleBackspace: HandleBackspaceFunc = (taskCard, subTaskId, event, dispatch, getToken) => {
+const handleBackspace: HandleBackspaceFunc = (taskCard, subTaskId, event, dispatch) => {
   event.preventDefault() // Prevents the last character of the task from being delete when the cursor jumps to the task above
-  deleteSubTask(taskCard, subTaskId, dispatch, getToken)
+  deleteSubTask(taskCard, subTaskId, dispatch)
 }
 
-const handleEnter: HandleEnterFunc = (taskCards, taskCardId, subTask, dispatch, getToken) => {
-  addNewSubTaskToCardOnEnterKeydown(taskCards[taskCardId], subTask.id, dispatch, getToken)
+const handleEnter: HandleEnterFunc = (taskCards, taskCardId, subTask, dispatch) => {
+  addNewSubTaskToCardOnEnterKeydown(taskCards[taskCardId], subTask.id, dispatch)
 }
 
 export const handleKeyDownOnSubTask: HandleKeyDownOnSubTaskFunc = (
@@ -41,12 +41,11 @@ export const handleKeyDownOnSubTask: HandleKeyDownOnSubTaskFunc = (
   taskCardId,
   subTask,
   event,
-  dispatch,
-  getToken
+  dispatch
 ) => {
   if (event.key === 'ArrowDown') handleArrowDown(taskCards, taskCardId, subTask)
   else if (event.key === 'ArrowUp') handleArrowUp(taskCards, taskCardId, subTask)
-  else if (event.key === 'Enter') handleEnter(taskCards, taskCardId, subTask, dispatch, getToken)
+  else if (event.key === 'Enter') handleEnter(taskCards, taskCardId, subTask, dispatch)
   else if (event.key === 'Backspace' && subTask.title === '')
-    handleBackspace(taskCards[taskCardId], subTask.id, event, dispatch, getToken)
+    handleBackspace(taskCards[taskCardId], subTask.id, event, dispatch)
 }

--- a/components/planner/Board/TaskColumns/TaskCard/TaskCardDialog/TaskCardDialog.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/TaskCardDialog/TaskCardDialog.tsx
@@ -7,7 +7,6 @@ import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
 import changeCardCheckedStatus from '@/utils/plannerUtils/cardUtils/changeCardCheckedStatus'
 import changeCardContent from '@/utils/plannerUtils/cardUtils/changeCardContent'
 import changeCardTitle from '@/utils/plannerUtils/cardUtils/changeCardTitle'
-import { useAuth } from '@clerk/nextjs'
 import { CategoryBadge } from '../CategoryBadge'
 import { EditableSubTasks } from './EditableSubTasks/EditableSubTasks'
 
@@ -19,8 +18,7 @@ type TaskCardDialogProps = {
 
 export const TaskCardDialog = ({ boardId, columnId, id }: TaskCardDialogProps) => {
   const dispatch = usePlannerDispatch()!
-  const { getToken } = useAuth()
-  const { taskCards } = usePlanner()
+  const { taskCards, columns } = usePlanner()
   const task = taskCards[id]
 
   return (
@@ -37,13 +35,13 @@ export const TaskCardDialog = ({ boardId, columnId, id }: TaskCardDialogProps) =
                   className='w-5 h-5'
                   checked={task.status === 'completed'}
                   onCheckedChange={(isChecked) =>
-                    changeCardCheckedStatus(columnId, id, Boolean(isChecked), dispatch, getToken)
+                    changeCardCheckedStatus(columnId, id, Boolean(isChecked), columns[columnId].taskCards, dispatch)
                   }
                 />
                 <Textarea
                   value={task.title}
                   className='items-center p-0 border-none h-[35px] text-2xl focus-visible:ring-0 focus-visible:ring-transparent resize-y'
-                  onChange={(event) => changeCardTitle(id, event.target.value, dispatch, getToken)}
+                  onChange={(event) => changeCardTitle(id, event.target.value, dispatch)}
                 />
               </div>
             </div>
@@ -56,7 +54,7 @@ export const TaskCardDialog = ({ boardId, columnId, id }: TaskCardDialogProps) =
             placeholder='Notes...'
             value={task.content}
             className='bg-neutral-100 m-1 min-h-fit focus-visible:ring-0 focus-visible:ring-transparent resize-y'
-            onChange={(event) => changeCardContent(id, event.target.value, dispatch, getToken)}
+            onChange={(event) => changeCardContent(id, event.target.value, dispatch)}
           />
         </CardContent>
         <CardFooter className='flex justify-between'></CardFooter>

--- a/components/planner/Board/TaskColumns/TaskColumns.tsx
+++ b/components/planner/Board/TaskColumns/TaskColumns.tsx
@@ -1,7 +1,6 @@
 'use client'
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area'
 import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
-import { useAuth } from '@clerk/nextjs'
 import { DragDropContext, Droppable } from '@hello-pangea/dnd'
 import { handleOnDragEnd, handleOnDragStart } from '../../utils'
 import { TaskColumn } from './TaskColumn'
@@ -9,14 +8,13 @@ import { TaskColumn } from './TaskColumn'
 export const TaskColumns = ({ boardId }: { boardId: string }) => {
   const plannerContext = usePlanner()
   const { boards } = plannerContext
-  const { getToken } = useAuth()
   const dispatch = usePlannerDispatch()
 
   return (
     <div className='flex flex-1'>
       <DragDropContext
         onDragStart={(dragStartObj) => handleOnDragStart(dragStartObj, dispatch)}
-        onDragEnd={(result) => handleOnDragEnd(result, dispatch, getToken, plannerContext, boardId)}
+        onDragEnd={(result) => handleOnDragEnd(result, dispatch, plannerContext, boardId)}
       >
         {/* droppableId doesn't matter here because it won't be interacting with other droppables */}
         <Droppable droppableId='all-columns' direction='horizontal' type='column'>

--- a/components/planner/Settings/ManageBoardsCard/AddNewBoardForm.tsx
+++ b/components/planner/Settings/ManageBoardsCard/AddNewBoardForm.tsx
@@ -4,7 +4,6 @@ import { Input } from '@/components/ui/input'
 import { NANOID } from '@/constants/constants'
 import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
 import { addNewBoardToPlanner } from '@/utils/plannerUtils/boardUtils/addNewBoardToPlanner'
-import { useAuth } from '@clerk/nextjs'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
@@ -17,7 +16,6 @@ type AddNewBoardFormProps = {
 }
 
 export const AddNewBoardForm = ({ isCallout = false, closeDialog }: AddNewBoardFormProps) => {
-  const { getToken } = useAuth()
   const router = useRouter()
   const dispatch = usePlannerDispatch()
   const { boardOrder } = usePlanner()
@@ -42,7 +40,7 @@ export const AddNewBoardForm = ({ isCallout = false, closeDialog }: AddNewBoardF
 
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     const boardId = NANOID()
-    addNewBoardToPlanner(boardId, values.boardName, dispatch, getToken)
+    addNewBoardToPlanner(boardId, values.boardName, dispatch)
     toast.success('Board added.')
     closeDialog()
     if (isCallout) {

--- a/components/planner/Settings/ManageBoardsCard/ModifyBoardDialogContent.tsx
+++ b/components/planner/Settings/ManageBoardsCard/ModifyBoardDialogContent.tsx
@@ -5,7 +5,6 @@ import { Input } from '@/components/ui/input'
 import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
 import { changeBoardInfo } from '@/utils/plannerUtils/boardUtils/changeBoardInfo'
 import deleteBoard from '@/utils/plannerUtils/boardUtils/deleteBoard'
-import { useAuth } from '@clerk/nextjs'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
@@ -24,7 +23,6 @@ const formSchema = z.object({
 })
 
 export const ModifyBoardDialogContent = ({ onCloseDialog, boardId }: ModifyBoardDialogContentProps) => {
-  const { getToken } = useAuth()
   const { boards } = usePlanner()
   const dispatch = usePlannerDispatch()
 
@@ -38,7 +36,7 @@ export const ModifyBoardDialogContent = ({ onCloseDialog, boardId }: ModifyBoard
 
   const onSubmit = (values: z.infer<typeof formSchema>) => {
     onCloseDialog()
-    changeBoardInfo(boardId, values.boardName, dispatch, getToken)
+    changeBoardInfo(boardId, values.boardName, dispatch)
     toast.success('Board name changed.')
   }
 
@@ -68,7 +66,7 @@ export const ModifyBoardDialogContent = ({ onCloseDialog, boardId }: ModifyBoard
             <ManageItemAlertDialog
               onCloseParentDialog={onCloseDialog}
               onClickDelete={() => {
-                deleteBoard(boardId, dispatch, getToken)
+                deleteBoard(boardId, dispatch)
                 toast.success('Board deleted.')
               }}
               isDeleteButtonDisabled={boards[boardId].columns.length > 0}

--- a/components/planner/Settings/ManageCategoriesCard/AddNewCategoryForm.tsx
+++ b/components/planner/Settings/ManageCategoriesCard/AddNewCategoryForm.tsx
@@ -6,7 +6,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { NANOID } from '@/constants/constants'
 import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
 import { addNewCategory } from '@/utils/plannerUtils/categoryUtils/addNewCategory'
-import { useAuth } from '@clerk/nextjs'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -32,7 +31,6 @@ function getRandomBadgeClassName() {
 }
 
 export const AddNewCategoryForm = ({ closeDialog }: AddNewCategoryFormProps) => {
-  const { getToken } = useAuth()
   const { boardOrder, boards } = usePlanner()
   const dispatch = usePlannerDispatch()
   const [selectedBoard, setSelectedBoard] = useState(boardOrder[0])
@@ -53,7 +51,7 @@ export const AddNewCategoryForm = ({ closeDialog }: AddNewCategoryFormProps) => 
       name: values.categoryName,
       color: categoryColor,
     }
-    addNewCategory(selectedBoard, newCategoryDetails, dispatch, getToken)
+    addNewCategory(selectedBoard, newCategoryDetails, dispatch)
     toast.success('Category added.')
     closeDialog()
   }

--- a/components/planner/Settings/ManageCategoriesCard/ModifyCategoryDialogContent.tsx
+++ b/components/planner/Settings/ManageCategoriesCard/ModifyCategoryDialogContent.tsx
@@ -8,7 +8,6 @@ import { UNASSIGNED_CATEGORY_NAME } from '@/constants/constants'
 import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
 import { changeCategoryInfo } from '@/utils/plannerUtils/categoryUtils/changeCategoryInfo'
 import deleteCategory from '@/utils/plannerUtils/categoryUtils/deleteCategory'
-import { useAuth } from '@clerk/nextjs'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -34,7 +33,6 @@ export const ModifyCategoryDialogContent = ({
   categoryId,
   onCloseDialog,
 }: ModifyCategoryDialogContentProps) => {
-  const { getToken } = useAuth()
   const { categories } = usePlanner()
   const dispatch = usePlannerDispatch()
 
@@ -49,7 +47,7 @@ export const ModifyCategoryDialogContent = ({
   const [categoryColor, setCategoryColor] = useState(categories[categoryId].color)
 
   const onSubmit = (values: z.infer<typeof formSchema>) => {
-    changeCategoryInfo(categoryId, values.categoryName, categoryColor, dispatch, getToken)
+    changeCategoryInfo(categoryId, values.categoryName, categoryColor, dispatch)
     onCloseDialog()
     toast.success('Category details changed.')
   }
@@ -84,7 +82,7 @@ export const ModifyCategoryDialogContent = ({
             <ManageItemAlertDialog
               onCloseParentDialog={onCloseDialog}
               onClickDelete={() => {
-                deleteCategory(boardId, categoryId, dispatch, getToken)
+                deleteCategory(boardId, categoryId, dispatch)
                 toast.success('Category deleted.')
               }}
               isDeleteButtonDisabled={false}

--- a/components/planner/Settings/ManageColumnsCard/AddNewColumnForm.tsx
+++ b/components/planner/Settings/ManageColumnsCard/AddNewColumnForm.tsx
@@ -3,7 +3,6 @@ import { Form, FormControl, FormField, FormItem, FormMessage } from '@/component
 import { Input } from '@/components/ui/input'
 import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
 import { addNewColumn } from '@/utils/plannerUtils/columnUtils/addNewColumn'
-import { useAuth } from '@clerk/nextjs'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
@@ -23,7 +22,6 @@ type AddNewColumnFormProps = {
 export const AddNewColumnForm = ({ boardId, closeDialog }: AddNewColumnFormProps) => {
   const { boards } = usePlanner()
   const dispatch = usePlannerDispatch()!
-  const { getToken } = useAuth()
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -34,7 +32,7 @@ export const AddNewColumnForm = ({ boardId, closeDialog }: AddNewColumnFormProps
 
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     const columnName = values.columnName
-    addNewColumn(boards[boardId], columnName, dispatch, getToken)
+    addNewColumn(boards[boardId], columnName, dispatch)
     toast.success('Column added.')
     closeDialog()
   }

--- a/components/planner/Settings/ManageColumnsCard/ModifyColumnDialogContent.tsx
+++ b/components/planner/Settings/ManageColumnsCard/ModifyColumnDialogContent.tsx
@@ -5,7 +5,6 @@ import { Input } from '@/components/ui/input'
 import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
 import changeColumnName from '@/utils/plannerUtils/columnUtils/changeColumnName'
 import deleteColumn from '@/utils/plannerUtils/columnUtils/deleteColumn'
-import { useAuth } from '@clerk/nextjs'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
@@ -25,7 +24,6 @@ const formSchema = z.object({
 })
 
 export const ModifyColumnDialogContent = ({ onCloseDialog, boardId, columnId }: ModifyBoardDialogContentProps) => {
-  const { getToken } = useAuth()
   const { columns } = usePlanner()
   const dispatch = usePlannerDispatch()
 
@@ -39,7 +37,7 @@ export const ModifyColumnDialogContent = ({ onCloseDialog, boardId, columnId }: 
 
   const onSubmit = (values: z.infer<typeof formSchema>) => {
     onCloseDialog()
-    changeColumnName(columnId, values.columnName, dispatch, getToken)
+    changeColumnName(columnId, values.columnName, dispatch)
     toast.success('Column name changed.')
   }
 
@@ -71,7 +69,7 @@ export const ModifyColumnDialogContent = ({ onCloseDialog, boardId, columnId }: 
               isDeleteButtonDisabled={columns[columnId].taskCards.length > 0}
               deleteButtonDisabledTooltipContent='A column with tasks cannot be deleted.'
               onClickDelete={() => {
-                deleteColumn(boardId, columnId, dispatch, getToken)
+                deleteColumn(boardId, columnId, dispatch)
                 toast.success('Column deleted.')
               }}
             />

--- a/components/planner/utils.ts
+++ b/components/planner/utils.ts
@@ -9,12 +9,11 @@ import type { DragStart, DropResult } from '@hello-pangea/dnd'
 type OnDragEndFunc = (
   result: DropResult,
   dispatch: PlannerDispatchContextType,
-  getToken: () => Promise<string | null>,
   plannerContext: PlannerType,
   boardId: string
 ) => void
 
-export const handleOnDragEnd: OnDragEndFunc = (result, dispatch, getToken, plannerContext, boardId) => {
+export const handleOnDragEnd: OnDragEndFunc = (result, dispatch, plannerContext, boardId) => {
   const { destination, source, draggableId, type } = result
   const { boards, columns, taskCards } = plannerContext
 
@@ -39,28 +38,20 @@ export const handleOnDragEnd: OnDragEndFunc = (result, dispatch, getToken, plann
   }
 
   if (type === 'subtask') {
-    return reorderSubTasks(taskCards, draggableId, source.index, destination.index, dispatch, getToken)
+    return reorderSubTasks(taskCards, draggableId, source.index, destination.index, dispatch)
   }
 
   if (type === 'column') {
-    return changeColumnOrder(boards, boardId, draggableId, source.index, destination.index, dispatch, getToken)
+    return changeColumnOrder(boards, boardId, draggableId, source.index, destination.index, dispatch)
   }
 
   // Moving a card within the same column
   if (columns[source.droppableId] === columns[destination.droppableId]) {
-    return moveCardWithinColumn(
-      columns,
-      source.droppableId,
-      draggableId,
-      source.index,
-      destination.index,
-      dispatch,
-      getToken
-    )
+    return moveCardWithinColumn(columns, source.droppableId, draggableId, source.index, destination.index, dispatch)
   }
 
   // Moving cards between columns
-  moveCardAcrossColumns(columns, draggableId, source, destination, dispatch, getToken)
+  moveCardAcrossColumns(columns, draggableId, source, destination, dispatch)
 }
 
 type OnDragStartFunction = (dragStartObj: DragStart, dispatch: PlannerDispatchContextType) => void

--- a/hooks/Planner/Planner.tsx
+++ b/hooks/Planner/Planner.tsx
@@ -1,27 +1,11 @@
-import { useAuth } from '@clerk/nextjs'
+import { emptyPlannerState, fetchPlannerData } from '@/utils/plannerUtils/apiClient'
 import axios from 'axios'
 import { Dispatch, createContext, useContext, useEffect, useReducer } from 'react'
 import { useErrorBoundary } from 'react-error-boundary'
 import { plannerReducer } from './plannerReducer'
 import { PlannerType } from './types'
 
-const initialEmptyState: PlannerType = {
-  hasLoaded: false,
-  backendErrorOccurred: false,
-  isSubTaskBeingDragged: false,
-  idOfCardBeingDragged: '',
-  taskCardBeingInitialized: null,
-  dataEnteredInTaskCardBeingInitialized: false,
-  scheduledTaskCards: [],
-  boardOrder: [],
-  boards: {},
-  columns: {},
-  categories: {},
-  taskCards: {},
-  subTasks: {},
-}
-
-export const PlannerContext = createContext<PlannerType>(initialEmptyState)
+export const PlannerContext = createContext<PlannerType>(emptyPlannerState)
 export const PlannerDispatchContext = createContext<Dispatch<any>>(() => {})
 
 export const usePlanner = () => {
@@ -34,40 +18,26 @@ export const usePlannerDispatch = () => {
 
 export const PlannerProvider = ({ children }: { children: JSX.Element | JSX.Element[] }) => {
   const { showBoundary } = useErrorBoundary()
-  const [plannerData, dispatch] = useReducer(plannerReducer, initialEmptyState)
-  const { getToken } = useAuth()
+  const [plannerData, dispatch] = useReducer(plannerReducer, emptyPlannerState)
 
   useEffect(() => {
-    const fetchData = async () => {
-      const token = await getToken()
-      axios
-        .get('/api/planner', {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        })
-        .then((response) => {
-          const data = response.data
-          dispatch({
-            type: 'dataFetchedFromDatabase',
-            payload: {
-              ...initialEmptyState,
-              hasLoaded: true,
-              boardOrder: data.boardOrder,
-              boards: data.boards,
-              columns: data.columns,
-              categories: data.categories,
-              taskCards: data.taskCards,
-              subTasks: data.subTasks,
-            },
-          })
-        })
-        .catch((error) => showBoundary(error))
+    if (plannerData.hasLoaded) {
+      return
     }
-    if (!plannerData.hasLoaded) {
-      fetchData()
-    }
-  }, [showBoundary, getToken, plannerData.hasLoaded])
+    // Abort on unmount so a StrictMode double-mount (or quick navigation) can't
+    // resolve a stale fetch over the live store.
+    const controller = new AbortController()
+    fetchPlannerData(controller.signal)
+      .then((payload) => {
+        dispatch({ type: 'dataFetchedFromDatabase', payload })
+      })
+      .catch((error) => {
+        if (!axios.isCancel(error)) {
+          showBoundary(error)
+        }
+      })
+    return () => controller.abort()
+  }, [showBoundary, plannerData.hasLoaded])
 
   return (
     <PlannerContext.Provider value={plannerData}>

--- a/hooks/Planner/plannerReducer.tsx
+++ b/hooks/Planner/plannerReducer.tsx
@@ -7,10 +7,6 @@ export const plannerReducer = produce((draft: Draft<PlannerType>, action) => {
     case 'dataFetchedFromDatabase': {
       return action.payload
     }
-    case 'backendErrorOccurred': {
-      draft.backendErrorOccurred = true
-      break
-    }
     case 'newBoardAdded': {
       const { boardId, boardName, unassignedCategoryDetails } = action.payload
       draft.boardOrder.push(boardId)
@@ -65,11 +61,6 @@ export const plannerReducer = produce((draft: Draft<PlannerType>, action) => {
       const { sourceColumnId, destColumnId, sourceColumnTaskCardIds, destColumnTaskCardIds } = action.payload
       draft.columns[sourceColumnId].taskCards = sourceColumnTaskCardIds
       draft.columns[destColumnId].taskCards = destColumnTaskCardIds
-      break
-    }
-    case 'cardScheduledOnCalendar': {
-      const { taskCardId } = action.payload
-      if (draft.scheduledTaskCards.indexOf(taskCardId) === -1) draft.scheduledTaskCards.push(taskCardId)
       break
     }
     // NO NEED

--- a/hooks/Planner/types.tsx
+++ b/hooks/Planner/types.tsx
@@ -77,12 +77,10 @@ export type BoardsType = {
 
 export type PlannerType = {
   hasLoaded: boolean
-  backendErrorOccurred: boolean
   isSubTaskBeingDragged: boolean
   idOfCardBeingDragged: string
   taskCardBeingInitialized: TaskCardBeingInitializedType | null
   dataEnteredInTaskCardBeingInitialized: boolean
-  scheduledTaskCards: string[]
   boardOrder: string[]
   boards: BoardsType
   columns: ColumnsType

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: false,
+  reactStrictMode: true,
   async headers() {
     return [
       {

--- a/utils/plannerUtils/apiClient.ts
+++ b/utils/plannerUtils/apiClient.ts
@@ -1,0 +1,89 @@
+import { DEBOUNCE_TIME_MS } from '@/constants/constants'
+import { PlannerType } from '@/hooks/Planner/types'
+import axios from 'axios'
+import { DebouncedFunc } from 'lodash'
+import debounce from 'lodash/debounce'
+import { Dispatch } from 'react'
+import { toast } from 'sonner'
+
+export const emptyPlannerState: PlannerType = {
+  hasLoaded: false,
+  isSubTaskBeingDragged: false,
+  idOfCardBeingDragged: '',
+  taskCardBeingInitialized: null,
+  dataEnteredInTaskCardBeingInitialized: false,
+  boardOrder: [],
+  boards: {},
+  columns: {},
+  categories: {},
+  taskCards: {},
+  subTasks: {},
+}
+
+export async function fetchPlannerData(signal?: AbortSignal): Promise<PlannerType> {
+  const { data } = await axios.get('/api/planner', { signal })
+  return {
+    ...emptyPlannerState,
+    hasLoaded: true,
+    boardOrder: data.boardOrder,
+    boards: data.boards,
+    columns: data.columns,
+    categories: data.categories,
+    taskCards: data.taskCards,
+    subTasks: data.subTasks,
+  }
+}
+
+/*
+ * Every mutation flows through one FIFO chain, so writes reach the server in
+ * dispatch order — a fast second drag can no longer overtake the first one's
+ * in-flight request and resurrect stale order.
+ *
+ * The UI updates optimistically before the request is sent. If a request
+ * fails, the store has diverged from the server, so recovery is: surface an
+ * error toast, then re-hydrate the store from the server once the queue
+ * drains. Convergent and simple, at the cost of discarding whatever optimistic
+ * edits were still in flight behind the failure.
+ */
+let writeChain: Promise<unknown> = Promise.resolve()
+let refetchScheduled = false
+
+export function sendMutation(dispatch: Dispatch<any>, request: () => Promise<unknown>): void {
+  writeChain = writeChain.then(request).catch((error) => {
+    console.error('Mutation failed:', error)
+    if (refetchScheduled) {
+      return
+    }
+    refetchScheduled = true
+    toast.error("Your last change couldn't be saved. Restoring your planner from the server.")
+    writeChain = writeChain.then(async () => {
+      refetchScheduled = false
+      try {
+        const payload = await fetchPlannerData()
+        dispatch({ type: 'dataFetchedFromDatabase', payload })
+      } catch {
+        toast.error('Could not reach the server. Recent changes may not be saved.')
+      }
+    })
+  })
+}
+
+/*
+ * Debounced variant for keystroke-driven saves, keyed per entity. The old
+ * implementation shared one module-level debounce across all entities, so
+ * editing card A's title and then clicking into card B within 500ms silently
+ * cancelled A's save forever.
+ */
+const debouncedSenders = new Map<string, DebouncedFunc<(dispatch: Dispatch<any>, request: () => Promise<unknown>) => void>>()
+
+export function sendDebouncedMutation(key: string, dispatch: Dispatch<any>, request: () => Promise<unknown>): void {
+  let sender = debouncedSenders.get(key)
+  if (!sender) {
+    sender = debounce((latestDispatch: Dispatch<any>, latestRequest: () => Promise<unknown>) => {
+      debouncedSenders.delete(key)
+      sendMutation(latestDispatch, latestRequest)
+    }, DEBOUNCE_TIME_MS)
+    debouncedSenders.set(key, sender)
+  }
+  sender(dispatch, request)
+}

--- a/utils/plannerUtils/boardUtils/addNewBoardToPlanner.ts
+++ b/utils/plannerUtils/boardUtils/addNewBoardToPlanner.ts
@@ -1,13 +1,9 @@
 import { UNASSIGNED_CATEGORY_COLOR, UNASSIGNED_CATEGORY_ID, UNASSIGNED_CATEGORY_NAME } from '@/constants/constants'
 import axios from 'axios'
 import { Dispatch } from 'react'
+import { sendMutation } from '../apiClient'
 
-export const addNewBoardToPlanner = async (
-  boardId: string,
-  boardName: string,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
-) => {
+export const addNewBoardToPlanner = (boardId: string, boardName: string, dispatch: Dispatch<any>) => {
   const unassignedCategoryDetails = {
     id: UNASSIGNED_CATEGORY_ID,
     name: UNASSIGNED_CATEGORY_NAME,
@@ -22,25 +18,11 @@ export const addNewBoardToPlanner = async (
       unassignedCategoryDetails,
     },
   })
-
-  const token = await getToken()
-  axios
-    .post(
-      '/api/planner/boards',
-      {
-        boardId,
-        boardName,
-        unassignedCategoryDetails,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    )
-    .catch((error) => {
-      dispatch({
-        type: 'backendErrorOccurred',
-      })
+  sendMutation(dispatch, () =>
+    axios.post('/api/planner/boards', {
+      boardId,
+      boardName,
+      unassignedCategoryDetails,
     })
+  )
 }

--- a/utils/plannerUtils/boardUtils/changeBoardInfo.ts
+++ b/utils/plannerUtils/boardUtils/changeBoardInfo.ts
@@ -1,12 +1,8 @@
 import axios from 'axios'
 import { Dispatch } from 'react'
+import { sendMutation } from '../apiClient'
 
-export const changeBoardInfo = async (
-  boardId: string,
-  newName: string,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
-) => {
+export const changeBoardInfo = (boardId: string, newName: string, dispatch: Dispatch<any>) => {
   dispatch({
     type: 'boardNameChanged',
     payload: {
@@ -14,22 +10,5 @@ export const changeBoardInfo = async (
       newName,
     },
   })
-  const token = await getToken()
-  axios
-    .patch(
-      `/api/planner/boards/${boardId}`,
-      {
-        newName,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    )
-    .catch((error) => {
-      dispatch({
-        type: 'backendErrorOccurred',
-      })
-    })
+  sendMutation(dispatch, () => axios.patch(`/api/planner/boards/${boardId}`, { newName }))
 }

--- a/utils/plannerUtils/boardUtils/deleteBoard.ts
+++ b/utils/plannerUtils/boardUtils/deleteBoard.ts
@@ -1,27 +1,13 @@
 import axios from 'axios'
 import { Dispatch } from 'react'
+import { sendMutation } from '../apiClient'
 
-export default async function deleteBoard(
-  boardId: string,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
-) {
+export default function deleteBoard(boardId: string, dispatch: Dispatch<any>) {
   dispatch({
     type: 'boardDeleted',
     payload: {
       boardId,
     },
   })
-  const token = await getToken()
-  axios
-    .delete(`/api/planner/boards/${boardId}`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    })
-    .catch((error) => {
-      dispatch({
-        type: 'backendErrorOccurred',
-      })
-    })
+  sendMutation(dispatch, () => axios.delete(`/api/planner/boards/${boardId}`))
 }

--- a/utils/plannerUtils/cardUtils/addNewCardToColumn.ts
+++ b/utils/plannerUtils/cardUtils/addNewCardToColumn.ts
@@ -1,8 +1,9 @@
 import { ColumnInfoType, TaskCardInfoType } from '@/hooks/Planner/types'
 import axios from 'axios'
 import { Dispatch } from 'react'
+import { sendMutation } from '../apiClient'
 
-export const addNewCardToColumn = async (
+export const addNewCardToColumn = (
   column: ColumnInfoType,
   cardDetails: {
     id: string
@@ -10,8 +11,7 @@ export const addNewCardToColumn = async (
     category: string
     content: string
   },
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
+  dispatch: Dispatch<any>
 ) => {
   const newTaskCardDetails: TaskCardInfoType = {
     id: cardDetails.id,
@@ -31,23 +31,10 @@ export const addNewCardToColumn = async (
       updatedTaskCards,
     },
   })
-  const token = await getToken()
-  axios
-    .post(
-      `/api/planner/columns/${column.id}/cards`,
-      {
-        newTaskCardDetails,
-        updatedTaskCards,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    )
-    .catch((error) => {
-      dispatch({
-        type: 'backendErrorOccurred',
-      })
+  sendMutation(dispatch, () =>
+    axios.post(`/api/planner/columns/${column.id}/cards`, {
+      newTaskCardDetails,
+      updatedTaskCards,
     })
+  )
 }

--- a/utils/plannerUtils/cardUtils/changeCardCategory.ts
+++ b/utils/plannerUtils/cardUtils/changeCardCategory.ts
@@ -1,12 +1,8 @@
 import axios from 'axios'
 import { Dispatch } from 'react'
+import { sendMutation } from '../apiClient'
 
-export default async function changeCardCategory(
-  taskCardId: string,
-  newCategoryId: string,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
-) {
+export default function changeCardCategory(taskCardId: string, newCategoryId: string, dispatch: Dispatch<any>) {
   dispatch({
     type: 'taskCategoryChanged',
     payload: {
@@ -14,22 +10,5 @@ export default async function changeCardCategory(
       newCategoryId,
     },
   })
-  const token = await getToken()
-  axios
-    .patch(
-      `/api/planner/cards/${taskCardId}`,
-      {
-        category: newCategoryId,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    )
-    .catch((error) => {
-      dispatch({
-        type: 'backendErrorOccurred',
-      })
-    })
+  sendMutation(dispatch, () => axios.patch(`/api/planner/cards/${taskCardId}`, { category: newCategoryId }))
 }

--- a/utils/plannerUtils/cardUtils/changeCardCheckedStatus.ts
+++ b/utils/plannerUtils/cardUtils/changeCardCheckedStatus.ts
@@ -1,12 +1,13 @@
 import axios from 'axios'
 import { Dispatch } from 'react'
+import { sendMutation } from '../apiClient'
 
-export default async function changeCardCheckedStatus(
+export default function changeCardCheckedStatus(
   columnId: string,
   taskCardId: string,
   isChecked: boolean,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
+  columnTaskCardIds: string[],
+  dispatch: Dispatch<any>
 ) {
   dispatch({
     type: 'taskCardCheckedStatusChanged',
@@ -17,22 +18,19 @@ export default async function changeCardCheckedStatus(
     },
   })
 
-  const token = await getToken()
-  axios
-    .patch(
-      `/api/planner/cards/${taskCardId}`,
-      {
-        status: isChecked ? 'completed' : 'created',
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    )
-    .catch((error) => {
-      dispatch({
-        type: 'backendErrorOccurred',
+  if (isChecked) {
+    // The reducer moves a completed card to the bottom of its column; mirror
+    // that here so the new order persists instead of diverging on reload.
+    const taskCardOrder = columnTaskCardIds.filter((id) => id !== taskCardId)
+    taskCardOrder.push(taskCardId)
+    sendMutation(dispatch, () =>
+      axios.patch(`/api/planner/cards/${taskCardId}`, {
+        status: 'completed',
+        columnId,
+        taskCardOrder,
       })
-    })
+    )
+  } else {
+    sendMutation(dispatch, () => axios.patch(`/api/planner/cards/${taskCardId}`, { status: 'created' }))
+  }
 }

--- a/utils/plannerUtils/cardUtils/changeCardContent.ts
+++ b/utils/plannerUtils/cardUtils/changeCardContent.ts
@@ -1,38 +1,8 @@
-import { DEBOUNCE_TIME_MS } from '@/constants/constants'
 import axios from 'axios'
-import debounce from 'lodash/debounce'
 import { Dispatch } from 'react'
+import { sendDebouncedMutation } from '../apiClient'
 
-const debouncedApiCall = debounce(
-  async (taskCardId: string, newContent: string, dispatch: Dispatch<any>, token: string | null) => {
-    axios
-      .patch(
-        `/api/planner/cards/${taskCardId}`,
-        {
-          content: newContent,
-        },
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      )
-      .catch((error) => {
-        dispatch({
-          type: 'backendErrorOccurred',
-        })
-      })
-  },
-  DEBOUNCE_TIME_MS
-)
-
-export default async function changeCardContent(
-  taskCardId: string,
-  newContent: string,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
-) {
-  const token = await getToken()
+export default function changeCardContent(taskCardId: string, newContent: string, dispatch: Dispatch<any>) {
   dispatch({
     type: 'taskCardContentChanged',
     payload: {
@@ -40,5 +10,7 @@ export default async function changeCardContent(
       newContent,
     },
   })
-  debouncedApiCall(taskCardId, newContent, dispatch, token)
+  sendDebouncedMutation(`card-content:${taskCardId}`, dispatch, () =>
+    axios.patch(`/api/planner/cards/${taskCardId}`, { content: newContent })
+  )
 }

--- a/utils/plannerUtils/cardUtils/changeCardTitle.ts
+++ b/utils/plannerUtils/cardUtils/changeCardTitle.ts
@@ -1,38 +1,8 @@
-import { DEBOUNCE_TIME_MS } from '@/constants/constants'
 import axios from 'axios'
-import debounce from 'lodash/debounce'
 import { Dispatch } from 'react'
+import { sendDebouncedMutation } from '../apiClient'
 
-const debouncedApiCall = debounce(
-  async (taskCardId: string, newTitle: string, dispatch: Dispatch<any>, token: string | null) => {
-    axios
-      .patch(
-        `/api/planner/cards/${taskCardId}`,
-        {
-          title: newTitle,
-        },
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      )
-      .catch((error) => {
-        dispatch({
-          type: 'backendErrorOccurred',
-        })
-      })
-  },
-  DEBOUNCE_TIME_MS
-)
-
-export default async function changeCardTitle(
-  taskCardId: string,
-  newTitle: string,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
-) {
-  const token = await getToken()
+export default function changeCardTitle(taskCardId: string, newTitle: string, dispatch: Dispatch<any>) {
   dispatch({
     type: 'taskCardTitleChanged',
     payload: {
@@ -40,5 +10,7 @@ export default async function changeCardTitle(
       newTitle,
     },
   })
-  debouncedApiCall(taskCardId, newTitle, dispatch, token)
+  sendDebouncedMutation(`card-title:${taskCardId}`, dispatch, () =>
+    axios.patch(`/api/planner/cards/${taskCardId}`, { title: newTitle })
+  )
 }

--- a/utils/plannerUtils/cardUtils/deleteCard.ts
+++ b/utils/plannerUtils/cardUtils/deleteCard.ts
@@ -1,12 +1,8 @@
 import axios from 'axios'
 import { Dispatch } from 'react'
+import { sendMutation } from '../apiClient'
 
-export default async function deleteCard(
-  columnId: string,
-  taskCardId: string,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
-) {
+export default function deleteCard(columnId: string, taskCardId: string, dispatch: Dispatch<any>) {
   dispatch({
     type: 'taskCardDeleted',
     payload: {
@@ -14,17 +10,5 @@ export default async function deleteCard(
       taskCardId,
     },
   })
-  const token = await getToken()
-
-  axios
-    .delete(`/api/planner/columns/${columnId}/cards/${taskCardId}`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    })
-    .catch((error) => {
-      dispatch({
-        type: 'backendErrorOccurred',
-      })
-    })
+  sendMutation(dispatch, () => axios.delete(`/api/planner/columns/${columnId}/cards/${taskCardId}`))
 }

--- a/utils/plannerUtils/cardUtils/moveCardAcrossColumns.ts
+++ b/utils/plannerUtils/cardUtils/moveCardAcrossColumns.ts
@@ -1,14 +1,15 @@
 import { ColumnsType } from '@/hooks/Planner/types'
+import type { DraggableLocation } from '@hello-pangea/dnd'
 import axios from 'axios'
 import { Dispatch } from 'react'
+import { sendMutation } from '../apiClient'
 
-export default async function moveCardAcrossColumns(
+export default function moveCardAcrossColumns(
   columns: ColumnsType,
   draggedCardId: string,
-  source: any,
-  destination: any,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
+  source: DraggableLocation,
+  destination: DraggableLocation,
+  dispatch: Dispatch<any>
 ) {
   const sourceColumnId = source.droppableId
   const sourceColumn = columns[sourceColumnId]
@@ -29,25 +30,12 @@ export default async function moveCardAcrossColumns(
       destColumnTaskCardIds,
     },
   })
-  const token = await getToken()
-  axios
-    .patch(
-      `/api/planner/cards/${draggedCardId}/move`,
-      {
-        sourceColumnId,
-        destColumnId,
-        sourceColumnTaskCardIds,
-        destColumnTaskCardIds,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    )
-    .catch((error) => {
-      dispatch({
-        type: 'backendErrorOccurred',
-      })
+  sendMutation(dispatch, () =>
+    axios.patch(`/api/planner/cards/${draggedCardId}/move`, {
+      sourceColumnId,
+      destColumnId,
+      sourceColumnTaskCardIds,
+      destColumnTaskCardIds,
     })
+  )
 }

--- a/utils/plannerUtils/cardUtils/moveCardWithinColumn.ts
+++ b/utils/plannerUtils/cardUtils/moveCardWithinColumn.ts
@@ -1,15 +1,15 @@
 import { ColumnsType } from '@/hooks/Planner/types'
 import axios from 'axios'
 import { Dispatch } from 'react'
+import { sendMutation } from '../apiClient'
 
-export default async function moveCardWithinColumn(
+export default function moveCardWithinColumn(
   columns: ColumnsType,
   columnId: string,
   cardId: string,
-  sourceIndex: any,
-  destIndex: any,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
+  sourceIndex: number,
+  destIndex: number,
+  dispatch: Dispatch<any>
 ) {
   const startingColumn = columns[columnId]
   const reorderedCardIds = Array.from(startingColumn.taskCards) // Copy of taskCards
@@ -23,20 +23,5 @@ export default async function moveCardWithinColumn(
       reorderedCardIds,
     },
   })
-  const token = await getToken()
-  axios
-    .patch(
-      `/api/planner/columns/${columnId}/cards/reorder`,
-      { reorderedCardIds },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    )
-    .catch((error) => {
-      dispatch({
-        type: 'backendErrorOccurred',
-      })
-    })
+  sendMutation(dispatch, () => axios.patch(`/api/planner/columns/${columnId}/cards/reorder`, { reorderedCardIds }))
 }

--- a/utils/plannerUtils/categoryUtils/addNewCategory.ts
+++ b/utils/plannerUtils/categoryUtils/addNewCategory.ts
@@ -1,15 +1,15 @@
 import axios from 'axios'
 import { Dispatch } from 'react'
+import { sendMutation } from '../apiClient'
 
-export const addNewCategory = async (
+export const addNewCategory = (
   boardId: string,
   newCategoryDetails: {
     id: string
     name: string
     color: string
   },
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
+  dispatch: Dispatch<any>
 ) => {
   dispatch({
     type: 'newCategoryAdded',
@@ -18,22 +18,5 @@ export const addNewCategory = async (
       newCategoryDetails,
     },
   })
-  const token = await getToken()
-  axios
-    .post(
-      `/api/planner/boards/${boardId}/categories`,
-      {
-        newCategoryDetails,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    )
-    .catch((error) => {
-      dispatch({
-        type: 'backendErrorOccurred',
-      })
-    })
+  sendMutation(dispatch, () => axios.post(`/api/planner/boards/${boardId}/categories`, { newCategoryDetails }))
 }

--- a/utils/plannerUtils/categoryUtils/changeCategoryInfo.ts
+++ b/utils/plannerUtils/categoryUtils/changeCategoryInfo.ts
@@ -1,13 +1,8 @@
 import axios from 'axios'
 import { Dispatch } from 'react'
+import { sendMutation } from '../apiClient'
 
-export const changeCategoryInfo = async (
-  categoryId: string,
-  newName: string,
-  newColor: string,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
-) => {
+export const changeCategoryInfo = (categoryId: string, newName: string, newColor: string, dispatch: Dispatch<any>) => {
   const categoryDetails = {
     id: categoryId,
     name: newName,
@@ -19,23 +14,5 @@ export const changeCategoryInfo = async (
       categoryDetails,
     },
   })
-  const token = await getToken()
-  axios
-    .patch(
-      `/api/planner/categories/${categoryId}`,
-      {
-        newName,
-        newColor,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    )
-    .catch((error) => {
-      dispatch({
-        type: 'backendErrorOccurred',
-      })
-    })
+  sendMutation(dispatch, () => axios.patch(`/api/planner/categories/${categoryId}`, { newName, newColor }))
 }

--- a/utils/plannerUtils/categoryUtils/deleteCategory.ts
+++ b/utils/plannerUtils/categoryUtils/deleteCategory.ts
@@ -1,12 +1,8 @@
 import axios from 'axios'
 import { Dispatch } from 'react'
+import { sendMutation } from '../apiClient'
 
-export default async function deleteCategory(
-  boardId: string,
-  categoryId: string,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
-) {
+export default function deleteCategory(boardId: string, categoryId: string, dispatch: Dispatch<any>) {
   dispatch({
     type: 'categoryDeleted',
     payload: {
@@ -14,16 +10,5 @@ export default async function deleteCategory(
       categoryId,
     },
   })
-  const token = await getToken()
-  axios
-    .delete(`/api/planner/boards/${boardId}/categories/${categoryId}`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    })
-    .catch((error) => {
-      dispatch({
-        type: 'backendErrorOccurred',
-      })
-    })
+  sendMutation(dispatch, () => axios.delete(`/api/planner/boards/${boardId}/categories/${categoryId}`))
 }

--- a/utils/plannerUtils/columnUtils/addNewColumn.ts
+++ b/utils/plannerUtils/columnUtils/addNewColumn.ts
@@ -2,13 +2,9 @@ import { NANOID } from '@/constants/constants'
 import { BoardInfoType } from '@/hooks/Planner/types'
 import axios from 'axios'
 import { Dispatch } from 'react'
+import { sendMutation } from '../apiClient'
 
-export const addNewColumn = async (
-  board: BoardInfoType,
-  newColumnName: string,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
-) => {
+export const addNewColumn = (board: BoardInfoType, newColumnName: string, dispatch: Dispatch<any>) => {
   const newColumnId = NANOID()
   const newColumnDetails = {
     id: newColumnId,
@@ -16,7 +12,7 @@ export const addNewColumn = async (
     taskCards: [],
   }
   const updatedColumns = Array.from(board.columns)
-  updatedColumns.push(newColumnDetails.id) // Add to beginning of array
+  updatedColumns.push(newColumnDetails.id)
   dispatch({
     type: 'newColumnAdded',
     payload: {
@@ -25,23 +21,10 @@ export const addNewColumn = async (
       updatedColumns,
     },
   })
-  const token = await getToken()
-  axios
-    .post(
-      `/api/planner/boards/${board.id}/columns`,
-      {
-        newColumnDetails,
-        updatedColumns,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    )
-    .catch((error) => {
-      dispatch({
-        type: 'backendErrorOccurred',
-      })
+  sendMutation(dispatch, () =>
+    axios.post(`/api/planner/boards/${board.id}/columns`, {
+      newColumnDetails,
+      updatedColumns,
     })
+  )
 }

--- a/utils/plannerUtils/columnUtils/changeColumnName.ts
+++ b/utils/plannerUtils/columnUtils/changeColumnName.ts
@@ -1,12 +1,8 @@
 import axios from 'axios'
 import { Dispatch } from 'react'
+import { sendMutation } from '../apiClient'
 
-export default async function changeColumnName(
-  columnId: string,
-  newName: string,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
-) {
+export default function changeColumnName(columnId: string, newName: string, dispatch: Dispatch<any>) {
   dispatch({
     type: 'columnNameChanged',
     payload: {
@@ -14,22 +10,5 @@ export default async function changeColumnName(
       newName,
     },
   })
-  const token = await getToken()
-  axios
-    .patch(
-      `/api/planner/columns/${columnId}`,
-      {
-        newName,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    )
-    .catch((error) => {
-      dispatch({
-        type: 'backendErrorOccurred',
-      })
-    })
+  sendMutation(dispatch, () => axios.patch(`/api/planner/columns/${columnId}`, { newName }))
 }

--- a/utils/plannerUtils/columnUtils/changeColumnOrder.ts
+++ b/utils/plannerUtils/columnUtils/changeColumnOrder.ts
@@ -1,15 +1,15 @@
 import { BoardsType } from '@/hooks/Planner/types'
 import axios from 'axios'
 import { Dispatch } from 'react'
+import { sendMutation } from '../apiClient'
 
-export const changeColumnOrder = async (
+export const changeColumnOrder = (
   boards: BoardsType,
   boardId: string,
   draggableId: string,
   sourceIndex: number,
   destIndex: number,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
+  dispatch: Dispatch<any>
 ) => {
   const newColumnOrder = Array.from(boards[boardId].columns)
   newColumnOrder.splice(sourceIndex, 1)
@@ -21,22 +21,5 @@ export const changeColumnOrder = async (
       newColumnOrder,
     },
   })
-  const token = await getToken()
-  axios
-    .patch(
-      `/api/planner/boards/${boardId}/columns/reorder`,
-      {
-        newColumnOrder,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    )
-    .catch((error) => {
-      dispatch({
-        type: 'backendErrorOccurred',
-      })
-    })
+  sendMutation(dispatch, () => axios.patch(`/api/planner/boards/${boardId}/columns/reorder`, { newColumnOrder }))
 }

--- a/utils/plannerUtils/columnUtils/deleteColumn.ts
+++ b/utils/plannerUtils/columnUtils/deleteColumn.ts
@@ -1,12 +1,8 @@
 import axios from 'axios'
 import { Dispatch } from 'react'
+import { sendMutation } from '../apiClient'
 
-export default async function deleteColumn(
-  boardId: string,
-  columnId: string,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
-) {
+export default function deleteColumn(boardId: string, columnId: string, dispatch: Dispatch<any>) {
   dispatch({
     type: 'columnDeleted',
     payload: {
@@ -14,17 +10,5 @@ export default async function deleteColumn(
       columnId,
     },
   })
-  const token = await getToken()
-
-  axios
-    .delete(`/api/planner/boards/${boardId}/columns/${columnId}`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    })
-    .catch((error) => {
-      dispatch({
-        type: 'backendErrorOccurred',
-      })
-    })
+  sendMutation(dispatch, () => axios.delete(`/api/planner/boards/${boardId}/columns/${columnId}`))
 }

--- a/utils/plannerUtils/subTaskUtils/addNewSubTaskToCard.ts
+++ b/utils/plannerUtils/subTaskUtils/addNewSubTaskToCard.ts
@@ -2,13 +2,13 @@ import { NANOID } from '@/constants/constants'
 import { TaskCardInfoType } from '@/hooks/Planner/types'
 import axios from 'axios'
 import { Dispatch } from 'react'
+import { sendMutation } from '../apiClient'
 
-const addNewSubTask = async (
+const addNewSubTask = (
   taskCardId: string,
   newSubTaskId: string,
   newSubTasksOrder: string[],
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
+  dispatch: Dispatch<any>
 ) => {
   const newSubTaskDetails = {
     id: newSubTaskId,
@@ -23,47 +23,29 @@ const addNewSubTask = async (
       newSubTasksOrder,
     },
   })
-  const token = await getToken()
-  axios
-    .post(
-      `/api/planner/cards/${taskCardId}/subtasks`,
-      {
-        newSubTaskDetails,
-        newSubTasksOrder,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    )
-    .catch((error) => {
-      dispatch({
-        type: 'backendErrorOccurred',
-      })
+  sendMutation(dispatch, () =>
+    axios.post(`/api/planner/cards/${taskCardId}/subtasks`, {
+      newSubTaskDetails,
+      newSubTasksOrder,
     })
+  )
 }
 
-export const addNewSubTaskToCardOnEnterKeydown = async (
+export const addNewSubTaskToCardOnEnterKeydown = (
   taskCard: TaskCardInfoType,
   existingSubTaskId: string,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
+  dispatch: Dispatch<any>
 ) => {
   const newSubTaskId = NANOID()
   const newSubTasksOrder = Array.from(taskCard.subTasks)
-  let subTaskIndex = newSubTasksOrder.findIndex((id: string) => id === existingSubTaskId)
+  const subTaskIndex = newSubTasksOrder.findIndex((id: string) => id === existingSubTaskId)
   newSubTasksOrder.splice(subTaskIndex + 1, 0, newSubTaskId)
-  addNewSubTask(taskCard.id, newSubTaskId, newSubTasksOrder, dispatch, getToken)
+  addNewSubTask(taskCard.id, newSubTaskId, newSubTasksOrder, dispatch)
 }
 
-export const addNewSubTaskOnButtonClick = async (
-  taskCard: TaskCardInfoType,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
-) => {
+export const addNewSubTaskOnButtonClick = (taskCard: TaskCardInfoType, dispatch: Dispatch<any>) => {
   const newSubTaskId = NANOID()
   const newSubTasksOrder = Array.from(taskCard.subTasks)
   newSubTasksOrder.push(newSubTaskId)
-  addNewSubTask(taskCard.id, newSubTaskId, newSubTasksOrder, dispatch, getToken)
+  addNewSubTask(taskCard.id, newSubTaskId, newSubTasksOrder, dispatch)
 }

--- a/utils/plannerUtils/subTaskUtils/changeSubTaskCheckedStatus.ts
+++ b/utils/plannerUtils/subTaskUtils/changeSubTaskCheckedStatus.ts
@@ -1,12 +1,8 @@
 import axios from 'axios'
 import { Dispatch } from 'react'
+import { sendMutation } from '../apiClient'
 
-export default async function changeSubTaskCheckedStatus(
-  subTaskId: string,
-  isChecked: boolean,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
-) {
+export default function changeSubTaskCheckedStatus(subTaskId: string, isChecked: boolean, dispatch: Dispatch<any>) {
   dispatch({
     type: 'subTasksCheckedStatusChanged',
     payload: {
@@ -14,22 +10,5 @@ export default async function changeSubTaskCheckedStatus(
       isChecked,
     },
   })
-  const token = await getToken()
-  axios
-    .patch(
-      `/api/planner/subtasks/${subTaskId}`,
-      {
-        checked: isChecked,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    )
-    .catch((error) => {
-      dispatch({
-        type: 'backendErrorOccurred',
-      })
-    })
+  sendMutation(dispatch, () => axios.patch(`/api/planner/subtasks/${subTaskId}`, { checked: isChecked }))
 }

--- a/utils/plannerUtils/subTaskUtils/changeSubTaskTitle.ts
+++ b/utils/plannerUtils/subTaskUtils/changeSubTaskTitle.ts
@@ -1,38 +1,8 @@
-import { DEBOUNCE_TIME_MS } from '@/constants/constants'
 import axios from 'axios'
-import debounce from 'lodash/debounce'
 import { Dispatch } from 'react'
+import { sendDebouncedMutation } from '../apiClient'
 
-const debouncedApiCall = debounce(
-  async (subTaskId: string, newTitle: string, dispatch: Dispatch<any>, token: string | null) => {
-    axios
-      .patch(
-        `/api/planner/subtasks/${subTaskId}`,
-        {
-          title: newTitle,
-        },
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      )
-      .catch((error) => {
-        dispatch({
-          type: 'backendErrorOccurred',
-        })
-      })
-  },
-  DEBOUNCE_TIME_MS
-)
-
-export default async function changeSubTaskTitle(
-  subTaskId: string,
-  newTitle: string,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
-) {
-  const token = await getToken()
+export default function changeSubTaskTitle(subTaskId: string, newTitle: string, dispatch: Dispatch<any>) {
   dispatch({
     type: 'subTaskTitleChanged',
     payload: {
@@ -40,5 +10,7 @@ export default async function changeSubTaskTitle(
       newTitle,
     },
   })
-  debouncedApiCall(subTaskId, newTitle, dispatch, token)
+  sendDebouncedMutation(`subtask-title:${subTaskId}`, dispatch, () =>
+    axios.patch(`/api/planner/subtasks/${subTaskId}`, { title: newTitle })
+  )
 }

--- a/utils/plannerUtils/subTaskUtils/deleteSubTask.ts
+++ b/utils/plannerUtils/subTaskUtils/deleteSubTask.ts
@@ -1,13 +1,9 @@
 import { TaskCardInfoType } from '@/hooks/Planner/types'
 import axios from 'axios'
 import { Dispatch } from 'react'
+import { sendMutation } from '../apiClient'
 
-export default async function deleteSubTask(
-  taskCard: TaskCardInfoType,
-  subTaskId: string,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
-) {
+export default function deleteSubTask(taskCard: TaskCardInfoType, subTaskId: string, dispatch: Dispatch<any>) {
   /* Moves cursor focus to subtask above using the subtask ID */
   const subTasksCopy = Array.from(taskCard.subTasks)
   const subTaskIndex = subTasksCopy.findIndex((id: string) => id === subTaskId)
@@ -24,16 +20,5 @@ export default async function deleteSubTask(
       newSubtasks,
     },
   })
-  const token = await getToken()
-  axios
-    .delete(`/api/planner/cards/${taskCard.id}/subtasks/${subTaskId}`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    })
-    .catch((error) => {
-      dispatch({
-        type: 'backendErrorOccurred',
-      })
-    })
+  sendMutation(dispatch, () => axios.delete(`/api/planner/cards/${taskCard.id}/subtasks/${subTaskId}`))
 }

--- a/utils/plannerUtils/subTaskUtils/reorderSubtasks.ts
+++ b/utils/plannerUtils/subTaskUtils/reorderSubtasks.ts
@@ -1,14 +1,14 @@
 import { TaskCardsType } from '@/hooks/Planner/types'
 import axios from 'axios'
 import { Dispatch } from 'react'
+import { sendMutation } from '../apiClient'
 
-export const reorderSubTasks = async (
+export const reorderSubTasks = (
   taskCards: TaskCardsType,
   draggableId: string,
-  sourceIndex: any,
-  destIndex: any,
-  dispatch: Dispatch<any>,
-  getToken: () => Promise<string | null>
+  sourceIndex: number,
+  destIndex: number,
+  dispatch: Dispatch<any>
 ) => {
   const [taskCardId, subTaskId] = draggableId.split('~')
   const reorderedSubTasks = Array.from(taskCards[taskCardId].subTasks)
@@ -21,22 +21,5 @@ export const reorderSubTasks = async (
       reorderedSubTasks,
     },
   })
-  const token = await getToken()
-  axios
-    .patch(
-      `/api/planner/cards/${taskCardId}/subtasks/move`,
-      {
-        reorderedSubTasks,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    )
-    .catch((error) => {
-      dispatch({
-        type: 'backendErrorOccurred',
-      })
-    })
+  sendMutation(dispatch, () => axios.patch(`/api/planner/cards/${taskCardId}/subtasks/move`, { reorderedSubTasks }))
 }


### PR DESCRIPTION
Phase 3 of the post-dossier revitalization. Kills the last two critical data-loss findings:

- **Failed saves were invisible** — all 23 mutation utils dispatched `backendErrorOccurred`, a flag nothing read; no rollback, no toast. Now: one FIFO write chain with error toast + automatic store re-hydration from the server on failure. The write-only flag is deleted everywhere.
- **The shared debounce that ate your edits** — one module-level lodash debounce across all entities meant editing card A then clicking card B within 500ms silently cancelled A's save. Now debounced per entity id.

Plus: drag-race ordering fixed (writes are serialized in dispatch order), checking a card persists its move-to-bottom reorder (used to live only in client memory), the Bearer-token ceremony is gone from all 20 utils + 19 call sites (Clerk's cookie already authenticates same-origin), AbortController on the initial fetch, `reactStrictMode: true`, dead `scheduledTaskCards` state removed.

Net: −418 lines. Verification: tsc clean, lint clean, production build passes, zero `getToken` references left in app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)