### PR TITLE
Typed actions + React correctness: kill Dispatch<any>, render storms, leaks

### DIFF
--- a/components/global/AlertCard/AlertCard.tsx
+++ b/components/global/AlertCard/AlertCard.tsx
@@ -3,7 +3,7 @@ import { AlertCircle } from 'lucide-react'
 import { FallbackProps } from 'react-error-boundary'
 
 export const logError = (error: Error, info: { componentStack: string }) => {
-  console.log('error occured lol', error)
+  console.error('Unhandled error reached the boundary:', error, info.componentStack)
 }
 
 export const AlertCard = ({ error, resetErrorBoundary }: FallbackProps) => {
@@ -13,20 +13,6 @@ export const AlertCard = ({ error, resetErrorBoundary }: FallbackProps) => {
         <AlertCircle className='w-4 h-4' />
         <AlertTitle>Error</AlertTitle>
         <AlertDescription>Sorry about that! Something went wrong. </AlertDescription>
-      </Alert>
-    </main>
-  )
-}
-
-export const BackendErrorAlertCard = () => {
-  return (
-    <main className='flex flex-col justify-center items-center gap-8 min-h-screen'>
-      <Alert className='w-fit' variant='destructive'>
-        <AlertCircle className='w-4 h-4' />
-        <AlertTitle>Error</AlertTitle>
-        <AlertDescription>
-          Sorry about that! Something went wrong. Please refresh the page to see if the problem persists.
-        </AlertDescription>
       </Alert>
     </main>
   )

--- a/components/planner/Board/Sidebar/Sidebar.tsx
+++ b/components/planner/Board/Sidebar/Sidebar.tsx
@@ -14,9 +14,9 @@ export const Sidebar = ({ currentPage }: { currentPage: string }) => {
       <div className='flex flex-col justify-between gap-2 w-full h-full'>
         <div>
           <div className='flex flex-col gap-2 w-full'>
-            {boardOrder.map((boardId, i) => (
+            {boardOrder.map((boardId) => (
               <SidebarButton
-                key={i}
+                key={boardId}
                 isCurrentlySelected={boardId === currentPage}
                 label={boards[boardId].name}
                 pathname={`/boards/${boardId}`}

--- a/components/planner/Board/Sidebar/SidebarButton.tsx
+++ b/components/planner/Board/Sidebar/SidebarButton.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@/components/ui/button'
-import { usePlannerFiltersDispatch } from '@/hooks/PlannerFilters/PlannerFilters'
 import { useRouter } from 'next/navigation'
 
 export const SidebarButton = ({
@@ -14,13 +13,14 @@ export const SidebarButton = ({
   icon?: React.ReactNode
 }) => {
   const router = useRouter()
-  const filtersDispatch = usePlannerFiltersDispatch()
   return (
     <Button
       variant={isCurrentlySelected ? 'default' : 'ghost'}
       onClick={() => {
+        // Filters live in a provider that remounts with each board page, so
+        // navigation resets them without an explicit dispatch. The old dispatch
+        // here landed in a default context value and silently no-opped anyway.
         router.push(pathname)
-        filtersDispatch({ type: 'filtersReset' })
       }}
     >
       <div className='flex justify-between gap-2 w-full'>

--- a/components/planner/Board/TaskColumns/ColumnTasks.tsx
+++ b/components/planner/Board/TaskColumns/ColumnTasks.tsx
@@ -3,14 +3,19 @@ import { usePlanner } from '@/hooks/Planner/Planner'
 import { usePlannerFilters } from '@/hooks/PlannerFilters/PlannerFilters'
 import { cn } from '@/lib/utils'
 import { Droppable } from '@hello-pangea/dnd'
+import { memo } from 'react'
 import { InitializingTaskCard } from './TaskCard/InitializingTaskCard/InitializingTaskCard'
 import { TaskCard } from './TaskCard/TaskCard'
 
-export const ColumnTasks = ({ boardId, columnId }: { boardId: string; columnId: string }) => {
+export const ColumnTasks = memo(function ColumnTasks({ boardId, columnId }: { boardId: string; columnId: string }) {
   const { boards, columns, taskCards, taskCardBeingInitialized } = usePlanner()
   const { searchQuery, selectedCategories } = usePlannerFilters()
   const categoriesInBoard = boards[boardId].categories
   const columnInfo = columns[columnId]
+  // While a filter is active the rendered list diverges from the canonical column order, so a drop
+  // index can't be mapped back to the right position in the canonical array. Dragging is disabled
+  // instead; filtering then mapping keeps Draggable indices consecutive, which the dnd library requires.
+  const isFilterActive = searchQuery !== '' || selectedCategories.length > 0
   return (
     <Droppable droppableId={columnInfo.id} type='card'>
       {(provided, snapshot) => (
@@ -29,7 +34,7 @@ export const ColumnTasks = ({ boardId, columnId }: { boardId: string; columnId: 
             )}
             {columnInfo.taskCards
               .filter((cardId) => categoriesInBoard.includes(taskCards[cardId].category))
-              .map((taskCardId, index) => {
+              .filter((taskCardId) => {
                 const doesTaskCardContentMatchSearchQuery = taskCards[taskCardId].title
                   .toLowerCase()
                   .includes(searchQuery.toLowerCase())
@@ -37,17 +42,18 @@ export const ColumnTasks = ({ boardId, columnId }: { boardId: string; columnId: 
                 const doesTaskCardBelongToSelectedCategories =
                   selectedCategories.length === 0 || selectedCategories.includes(taskCards[taskCardId].category)
 
-                if (doesTaskCardContentMatchSearchQuery && doesTaskCardBelongToSelectedCategories)
-                  return (
-                    <TaskCard
-                      key={taskCardId}
-                      index={index}
-                      boardId={boardId}
-                      columnId={columnId}
-                      taskCardId={taskCardId}
-                    />
-                  )
-              })}
+                return doesTaskCardContentMatchSearchQuery && doesTaskCardBelongToSelectedCategories
+              })
+              .map((taskCardId, index) => (
+                <TaskCard
+                  key={taskCardId}
+                  index={index}
+                  boardId={boardId}
+                  columnId={columnId}
+                  taskCardId={taskCardId}
+                  isDragDisabled={isFilterActive}
+                />
+              ))}
             {provided.placeholder}
           </div>
           <ScrollBar orientation='vertical' />
@@ -55,4 +61,4 @@ export const ColumnTasks = ({ boardId, columnId }: { boardId: string; columnId: 
       )}
     </Droppable>
   )
-}
+})

--- a/components/planner/Board/TaskColumns/TaskCard/InitializingTaskCard/CancelButton.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/InitializingTaskCard/CancelButton.tsx
@@ -64,6 +64,7 @@ export const CancelButton = ({ isFormEmpty }: CancelButtonProps) => {
               })
               plannerDispatch({
                 type: 'dataEnteredInTaskCardBeingInitializedStatusChanged',
+                payload: false,
               })
             }}
           >

--- a/components/planner/Board/TaskColumns/TaskCard/InitializingTaskCard/InitializingTaskCard.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/InitializingTaskCard/InitializingTaskCard.tsx
@@ -8,7 +8,7 @@ import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
 import { cn } from '@/lib/utils'
 import { addNewCardToColumn } from '@/utils/plannerUtils/cardUtils/addNewCardToColumn'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import * as z from 'zod'
@@ -42,18 +42,24 @@ export const InitializingTaskCard = ({ boardId, columnId }: InitializingTaskCard
 
   const [isFormEmpty, setIsFormEmpty] = useState(true)
 
-  form.watch((value) => {
-    dispatch({
-      type: 'taskCardBeingInitializedHighlightStatusChange',
-      payload: false,
+  // The callback form of watch() registers a subscription, so it belongs in an
+  // effect with cleanup — calling it in the render body leaked one subscription
+  // per keystroke.
+  useEffect(() => {
+    const subscription = form.watch((value) => {
+      dispatch({
+        type: 'taskCardBeingInitializedHighlightStatusChange',
+        payload: false,
+      })
+      const dataEntered = value.taskCardTitle !== '' || value.taskCardDesc !== ''
+      setIsFormEmpty(!dataEntered)
+      dispatch({
+        type: 'dataEnteredInTaskCardBeingInitializedStatusChanged',
+        payload: dataEntered,
+      })
     })
-    const dataEntered = value.taskCardTitle !== '' || value.taskCardDesc !== ''
-    setIsFormEmpty(!dataEntered)
-    dispatch({
-      type: 'dataEnteredInTaskCardBeingInitializedStatusChanged',
-      payload: dataEntered,
-    })
-  })
+    return () => subscription.unsubscribe()
+  }, [form, dispatch])
 
   const onSubmit = (values: z.infer<typeof formSchema>) => {
     const newTaskCardDetails = {

--- a/components/planner/Board/TaskColumns/TaskCard/TaskCard.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/TaskCard.tsx
@@ -6,6 +6,7 @@ import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
 import { cn } from '@/lib/utils'
 import changeCardCheckedStatus from '@/utils/plannerUtils/cardUtils/changeCardCheckedStatus'
 import { Draggable } from '@hello-pangea/dnd'
+import { memo } from 'react'
 import { toast } from 'sonner'
 import { CategoryBadge } from './CategoryBadge'
 import { ProgressBar } from './ProgressBar'
@@ -18,6 +19,7 @@ type TaskCardProps = {
   boardId: string
   columnId: string
   taskCardId: string
+  isDragDisabled: boolean
 }
 
 type TaskCardWrapperProps = {
@@ -25,20 +27,23 @@ type TaskCardWrapperProps = {
   boardId: string
   columnId: string
   taskCardId: string
-  children: JSX.Element
+  isDragDisabled: boolean
+  children: (isDragging: boolean) => JSX.Element
 }
 
-const TaskCardWrapper = ({ index, boardId, columnId, taskCardId, children }: TaskCardWrapperProps) => {
+// children is a render function so that snapshot.isDragging (only available inside the Draggable
+// render prop) can be delivered to the card markup without going through global state.
+const TaskCardWrapper = ({ index, boardId, columnId, taskCardId, isDragDisabled, children }: TaskCardWrapperProps) => {
   return (
-    <Draggable draggableId={taskCardId} index={index}>
-      {(provided) => (
+    <Draggable draggableId={taskCardId} index={index} isDragDisabled={isDragDisabled}>
+      {(provided, snapshot) => (
         <div {...provided.draggableProps} {...provided.dragHandleProps} ref={provided.innerRef} className='my-1 w-full'>
           <Dialog>
             <ContextMenu>
               <TaskCardContextMenu columnId={columnId} taskCardId={taskCardId} />
               <ContextMenuTrigger>
                 {/* Dialog is the one that shows when you click on a card. This allows you to edit a card's information*/}
-                <DialogTrigger asChild>{children}</DialogTrigger>
+                <DialogTrigger asChild>{children(snapshot.isDragging)}</DialogTrigger>
               </ContextMenuTrigger>
             </ContextMenu>
             <TaskCardDialog boardId={boardId} columnId={columnId} id={taskCardId} />
@@ -49,55 +54,65 @@ const TaskCardWrapper = ({ index, boardId, columnId, taskCardId, children }: Tas
   )
 }
 
-export const TaskCard = ({ index, boardId, columnId, taskCardId }: TaskCardProps) => {
-  // idOfCardBeingDragged is consumed from a context due to the fact that the snapshot object (which has an isDragging flag),
-  // was in the wrapper component. There was no straightforward way to pass that info down to it's children (i.e. TaskCard).
-  // Using ContextProvider is possible but was way too convoluted- i.e. the isDragging property wouldn't cause re-renders,
-  // and thus the card wouldn't turn transparent, which is the reason why we need to know if the card is being dragged.
+export const TaskCard = memo(function TaskCard({
+  index,
+  boardId,
+  columnId,
+  taskCardId,
+  isDragDisabled,
+}: TaskCardProps) {
   const dispatch = usePlannerDispatch()
-  const { taskCards, columns, idOfCardBeingDragged } = usePlanner()
+  const { taskCards, columns } = usePlanner()
   const task = taskCards[taskCardId]
 
   return (
-    <TaskCardWrapper index={index} boardId={boardId} columnId={columnId} taskCardId={taskCardId}>
-      <Card
-        className={cn(
-          idOfCardBeingDragged === taskCardId ? 'backdrop-blur-sm bg-white/70' : '',
-          task.status === 'completed' ? 'opacity-50' : ''
-        )}
-      >
-        <CardHeader className='p-4'>
-          <div className='flex flex-col justify-between items-start'>
-            <CardTitle className='text-xl'>{task.title}</CardTitle>
-          </div>
-        </CardHeader>
-        {task.subTasks.length > 0 && (
-          <CardContent className='flex flex-col gap-2 px-4'>
-            <SubTasks taskCardId={task.id} />
-            <ProgressBar taskCardId={taskCardId} />
-          </CardContent>
-        )}
-        <CardFooter className='flex justify-between px-4 pb-4'>
-          <div className='flex items-center gap-2'>
-            <Checkbox
-              className='rounded-xl w-5 h-5'
-              checked={task.status === 'completed'}
-              onClick={(event) => {
-                event.preventDefault() // Needed to prevent dialog from triggering
-                const isChecked = (event.target as HTMLButtonElement).getAttribute('data-state') === 'checked'
-                if (!isChecked) {
-                  // Means the card was just checked, condition might be confusing
-                  toast.success('Task marked as complete.')
-                } else {
-                  toast.info('Task marked as incomplete.')
-                }
-                changeCardCheckedStatus(columnId, taskCardId, !isChecked, columns[columnId].taskCards, dispatch)
-              }}
-            />
-          </div>
-          <CategoryBadge boardId={boardId} taskCardId={taskCardId} />
-        </CardFooter>
-      </Card>
+    <TaskCardWrapper
+      index={index}
+      boardId={boardId}
+      columnId={columnId}
+      taskCardId={taskCardId}
+      isDragDisabled={isDragDisabled}
+    >
+      {(isDragging) => (
+        <Card
+          className={cn(
+            isDragging ? 'backdrop-blur-sm bg-white/70' : '',
+            task.status === 'completed' ? 'opacity-50' : ''
+          )}
+        >
+          <CardHeader className='p-4'>
+            <div className='flex flex-col justify-between items-start'>
+              <CardTitle className='text-xl'>{task.title}</CardTitle>
+            </div>
+          </CardHeader>
+          {task.subTasks.length > 0 && (
+            <CardContent className='flex flex-col gap-2 px-4'>
+              <SubTasks taskCardId={task.id} />
+              <ProgressBar taskCardId={taskCardId} />
+            </CardContent>
+          )}
+          <CardFooter className='flex justify-between px-4 pb-4'>
+            <div className='flex items-center gap-2'>
+              <Checkbox
+                className='rounded-xl w-5 h-5'
+                checked={task.status === 'completed'}
+                onClick={(event) => {
+                  event.preventDefault() // Needed to prevent dialog from triggering
+                  const isChecked = (event.target as HTMLButtonElement).getAttribute('data-state') === 'checked'
+                  if (!isChecked) {
+                    // Means the card was just checked, condition might be confusing
+                    toast.success('Task marked as complete.')
+                  } else {
+                    toast.info('Task marked as incomplete.')
+                  }
+                  changeCardCheckedStatus(columnId, taskCardId, !isChecked, columns[columnId].taskCards, dispatch)
+                }}
+              />
+            </div>
+            <CategoryBadge boardId={boardId} taskCardId={taskCardId} />
+          </CardFooter>
+        </Card>
+      )}
     </TaskCardWrapper>
   )
-}
+})

--- a/components/planner/Board/TaskColumns/TaskCard/TaskCardDialog/EditableSubTasks/EditableSubTasks.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/TaskCardDialog/EditableSubTasks/EditableSubTasks.tsx
@@ -1,5 +1,6 @@
 import { usePlanner } from '@/hooks/Planner/Planner'
 import { Draggable, Droppable } from '@hello-pangea/dnd'
+import { useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { AddNewSubTaskButton } from '../AddNewSubTaskButton'
 import { EditableSubTask } from './EditableSubTask'
@@ -12,17 +13,25 @@ export const EditableSubTasks = ({ taskCardId }: EditableSubTasksProps) => {
   const { taskCards, subTasks } = usePlanner()
   const subTasksUnderTaskCard = taskCards[taskCardId].subTasks.map((subTaskId) => subTasks[subTaskId])
 
-  // ------------------------------------------------------------------------------------------------------------------------------------------------
-
   // The createPortal is used to create a new portal for the sub tasks whenever they're being dragged.
   // The Dialog component was messing with how the drag and drop functionality of react-pangea-dnd was working.
   // If the createPortal isn't called conditionally, the dragged subtasks render outside the dialog (towards the
   // bottom right of the screen). Setting position to fixed or top and left to 0 caused every dragged item to
   // start from the top of the sub task container, which looked really bad. Portals are the only solution.
-  const portal: HTMLElement = document.createElement('div')
-  document.body.appendChild(portal)
-
-  // ------------------------------------------------------------------------------------------------------------------------------------------------
+  // One node per mount, removed on unmount — the old version appended a fresh div to body on every render.
+  const portalRef = useRef<HTMLElement | null>(null)
+  if (portalRef.current === null && typeof document !== 'undefined') {
+    portalRef.current = document.createElement('div')
+  }
+  useEffect(() => {
+    const portal = portalRef.current
+    if (!portal) return
+    document.body.appendChild(portal)
+    return () => {
+      document.body.removeChild(portal)
+    }
+  }, [])
+  const portal = portalRef.current
 
   return (
     <Droppable droppableId={taskCardId} type='subtask'>
@@ -31,7 +40,7 @@ export const EditableSubTasks = ({ taskCardId }: EditableSubTasksProps) => {
           {subTasksUnderTaskCard.map((subTask, index) => (
             <Draggable key={subTask.id} draggableId={`${taskCardId}~${subTask.id}`} index={index}>
               {(provided, snapshot) => {
-                if (snapshot.isDragging)
+                if (snapshot.isDragging && portal)
                   return createPortal(
                     <EditableSubTask
                       index={index}

--- a/components/planner/Board/TaskColumns/TaskColumn.tsx
+++ b/components/planner/Board/TaskColumns/TaskColumn.tsx
@@ -1,6 +1,7 @@
 import { usePlanner } from '@/hooks/Planner/Planner'
 import { cn } from '@/lib/utils'
 import { Draggable } from '@hello-pangea/dnd'
+import { memo } from 'react'
 import { ColumnHeader } from './ColumnHeader'
 import { ColumnTasks } from './ColumnTasks'
 
@@ -10,7 +11,7 @@ type TaskColumnProps = {
   columnId: string
 }
 
-export const TaskColumn = ({ index, boardId, columnId }: TaskColumnProps) => {
+export const TaskColumn = memo(function TaskColumn({ index, boardId, columnId }: TaskColumnProps) {
   const { boards, columns } = usePlanner()
   const columnInfo = columns[columnId]
   return (
@@ -28,4 +29,4 @@ export const TaskColumn = ({ index, boardId, columnId }: TaskColumnProps) => {
       )}
     </Draggable>
   )
-}
+})

--- a/components/planner/Settings/ManageBoardsCard/ManageBoardsCard.tsx
+++ b/components/planner/Settings/ManageBoardsCard/ManageBoardsCard.tsx
@@ -1,11 +1,37 @@
 import { Button } from '@/components/ui/button'
 import { DialogTrigger } from '@/components/ui/dialog'
 import { usePlanner } from '@/hooks/Planner/Planner'
-import { useState } from 'react'
+import { BoardsType } from '@/hooks/Planner/types'
+import { Dispatch, SetStateAction, useState } from 'react'
 import { ManageItemCardDialogWrapper } from '../ManageItemCardDialogWrapper'
 import { SectionTitleAndDescription } from '../SectionTitleAndDescription'
 import { AddNewBoardButton } from './AddNewBoardButton'
 import { ModifyBoardDialogContent } from './ModifyBoardDialogContent'
+
+type BoardsProps = {
+  boardOrder: string[]
+  boards: BoardsType
+  setBoardBeingModified: Dispatch<SetStateAction<string>>
+}
+
+const Boards = ({ boardOrder, boards, setBoardBeingModified }: BoardsProps) => {
+  return (
+    <div className='flex gap-2'>
+      {boardOrder.map((boardId) => (
+        <DialogTrigger key={boardId} asChild>
+          <Button
+            variant='secondary'
+            onClick={() => {
+              setBoardBeingModified(boardId)
+            }}
+          >
+            <span>{boards[boardId].name}</span>
+          </Button>
+        </DialogTrigger>
+      ))}
+    </div>
+  )
+}
 
 export const ManageBoardsCard = () => {
   const { boardOrder, boards } = usePlanner()
@@ -18,25 +44,6 @@ export const ManageBoardsCard = () => {
     setKey((prevKey) => prevKey + 1) // Resets unsaved changes in dialog when cancel button is clicked
   }
 
-  const Boards = () => {
-    return (
-      <div className='flex gap-2'>
-        {boardOrder.map((boardId) => (
-          <DialogTrigger key={boardId} asChild>
-            <Button
-              variant='secondary'
-              onClick={() => {
-                setBoardBeingModified(boardId)
-              }}
-            >
-              <span>{boards[boardId].name}</span>
-            </Button>
-          </DialogTrigger>
-        ))}
-      </div>
-    )
-  }
-
   return (
     <ManageItemCardDialogWrapper onCloseDialog={onCloseDialog} conditionToOpenDialog={conditionToOpenDialog}>
       <div className='flex flex-col items-start gap-5 w-full'>
@@ -45,7 +52,7 @@ export const ManageBoardsCard = () => {
           description='We recommend naming a board after an area of your life, i.e. Work, Home, etc.'
         />
         <div className='flex flex-row gap-2'>
-          <Boards />
+          <Boards boardOrder={boardOrder} boards={boards} setBoardBeingModified={setBoardBeingModified} />
         </div>
         <AddNewBoardButton />
         {conditionToOpenDialog && (

--- a/components/planner/Settings/ManageCategoriesCard/ManageCategoriesCard.tsx
+++ b/components/planner/Settings/ManageCategoriesCard/ManageCategoriesCard.tsx
@@ -2,20 +2,76 @@ import { Badge } from '@/components/ui/badge'
 import { DialogTrigger } from '@/components/ui/dialog'
 import { UNASSIGNED_CATEGORY_ID } from '@/constants/constants'
 import { usePlanner } from '@/hooks/Planner/Planner'
+import { BoardsType, CategoriesType } from '@/hooks/Planner/types'
 import { cn } from '@/lib/utils'
-import { useState } from 'react'
+import { Dispatch, SetStateAction, useState } from 'react'
 import { badgeClassNames } from '../../Board/TaskColumns/TaskCard/utils'
 import { ManageItemCardDialogWrapper } from '../ManageItemCardDialogWrapper'
 import { SectionTitleAndDescription } from '../SectionTitleAndDescription'
 import { AddNewCategoryButton } from './AddNewCategoryButton'
 import { ModifyCategoryDialogContent } from './ModifyCategoryDialogContent'
 
+type DetailsOfCategoryBeingModified = {
+  boardId: string
+  categoryId: string
+}
+
+type CategoriesProps = {
+  boardOrder: string[]
+  boards: BoardsType
+  categories: CategoriesType
+  setDetailsOfCategoryBeingModified: Dispatch<SetStateAction<DetailsOfCategoryBeingModified>>
+}
+
+const Categories = ({ boardOrder, boards, categories, setDetailsOfCategoryBeingModified }: CategoriesProps) => (
+  <div className='flex justify-start items-start gap-2 w-full'>
+    {boardOrder.map((boardId) => {
+      if (boards[boardId].categories.filter((category) => category !== UNASSIGNED_CATEGORY_ID).length === 0) {
+        return (
+          <div key={boardId} className='flex flex-col gap-2 w-48'>
+            <span className='text-lg'>{boards[boardId].name}</span>
+            <span className='text-neutral-500 text-sm'>0 categories</span>
+          </div>
+        )
+      }
+      return (
+        <div key={boardId} className='flex flex-col gap-2'>
+          <span className='text-lg'>{boards[boardId].name}</span>
+          {boards[boardId].categories.map((categoryId: string) => {
+            const category = categories[categoryId]
+            if (category.id !== UNASSIGNED_CATEGORY_ID) {
+              return (
+                <div key={categoryId} className='w-48'>
+                  <DialogTrigger asChild>
+                    <Badge
+                      className={cn('cursor-pointer', badgeClassNames[category.color])}
+                      onClick={() => {
+                        setDetailsOfCategoryBeingModified({
+                          boardId: boardId,
+                          categoryId: categoryId,
+                        })
+                      }}
+                    >
+                      {category.name}
+                    </Badge>
+                  </DialogTrigger>
+                </div>
+              )
+            }
+          })}
+        </div>
+      )
+    })}
+  </div>
+)
+
 export const ManageCategoriesCard = () => {
   const { boardOrder, boards, categories } = usePlanner()
-  const [detailsOfCategoryBeingModified, setDetailsOfCategoryBeingModified] = useState({
-    boardId: '',
-    categoryId: '',
-  })
+  const [detailsOfCategoryBeingModified, setDetailsOfCategoryBeingModified] =
+    useState<DetailsOfCategoryBeingModified>({
+      boardId: '',
+      categoryId: '',
+    })
   const [key, setKey] = useState(0)
   const conditionToOpenDialog = Boolean(
     detailsOfCategoryBeingModified.boardId && detailsOfCategoryBeingModified.categoryId
@@ -29,49 +85,6 @@ export const ManageCategoriesCard = () => {
     setKey((prevKey) => prevKey + 1) // Resets unsaved changes in dialog when cancel button is clicked.
   }
 
-  const Categories = () => (
-    <div className='flex justify-start items-start gap-2 w-full'>
-      {boardOrder.map((boardId) => {
-        if (boards[boardId].categories.filter((category) => category !== UNASSIGNED_CATEGORY_ID).length === 0) {
-          return (
-            <div key={boardId} className='flex flex-col gap-2 w-48'>
-              <span className='text-lg'>{boards[boardId].name}</span>
-              <span className='text-neutral-500 text-sm'>0 categories</span>
-            </div>
-          )
-        }
-        return (
-          <div key={boardId} className='flex flex-col gap-2'>
-            <span className='text-lg'>{boards[boardId].name}</span>
-            {boards[boardId].categories.map((categoryId: string, i: number) => {
-              const category = categories[categoryId]
-              if (category.id !== UNASSIGNED_CATEGORY_ID) {
-                return (
-                  <div key={`${category.name}-${i}`} className='w-48'>
-                    <DialogTrigger asChild>
-                      <Badge
-                        key={`filterbadge-${i}`}
-                        className={cn('cursor-pointer', badgeClassNames[category.color])}
-                        onClick={() => {
-                          setDetailsOfCategoryBeingModified({
-                            boardId: boardId,
-                            categoryId: categoryId,
-                          })
-                        }}
-                      >
-                        {category.name}
-                      </Badge>
-                    </DialogTrigger>
-                  </div>
-                )
-              }
-            })}
-          </div>
-        )
-      })}
-    </div>
-  )
-
   return (
     <ManageItemCardDialogWrapper onCloseDialog={onCloseDialog} conditionToOpenDialog={conditionToOpenDialog}>
       <div className='flex flex-col items-start gap-5'>
@@ -79,7 +92,12 @@ export const ManageCategoriesCard = () => {
           title='Categories'
           description='Categories are specific to a board. Think of them as tags.'
         />
-        <Categories />
+        <Categories
+          boardOrder={boardOrder}
+          boards={boards}
+          categories={categories}
+          setDetailsOfCategoryBeingModified={setDetailsOfCategoryBeingModified}
+        />
         <AddNewCategoryButton />
         {conditionToOpenDialog && (
           <ModifyCategoryDialogContent

--- a/components/planner/Settings/ManageColumnsCard/ManageColumnsCard.tsx
+++ b/components/planner/Settings/ManageColumnsCard/ManageColumnsCard.tsx
@@ -2,11 +2,69 @@ import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { usePlanner } from '@/hooks/Planner/Planner'
-import { useState } from 'react'
+import { BoardInfoType, BoardsType, ColumnsType } from '@/hooks/Planner/types'
+import { Dispatch, SetStateAction, useState } from 'react'
 import { ManageItemCardDialogWrapper } from '../ManageItemCardDialogWrapper'
 import { SectionTitleAndDescription } from '../SectionTitleAndDescription'
 import { AddNewColumnButton } from './AddNewColumnButton'
 import { ModifyColumnDialogContent } from './ModifyColumnDialogContent'
+
+type BoardSelectorProps = {
+  boardOrder: string[]
+  boards: BoardsType
+  selectedBoard: string
+  setSelectedBoard: Dispatch<SetStateAction<string>>
+}
+
+const BoardSelector = ({ boardOrder, boards, selectedBoard, setSelectedBoard }: BoardSelectorProps) => {
+  return (
+    <div className='flex flex-col gap-2 w-96'>
+      <Label htmlFor='board-selector'>Board</Label>
+      <Select onValueChange={(value) => setSelectedBoard(value)} value={selectedBoard}>
+        <SelectTrigger id='board-selector'>
+          <SelectValue placeholder='Select a board' />
+        </SelectTrigger>
+        <SelectContent>
+          {boardOrder.map((boardId: string) => (
+            <SelectItem key={boardId} value={boardId}>
+              {boards[boardId].name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+type ColumnsProps = {
+  board: BoardInfoType | undefined
+  columns: ColumnsType
+  setColumnBeingModified: Dispatch<SetStateAction<string>>
+}
+
+const Columns = ({ board, columns, setColumnBeingModified }: ColumnsProps) => {
+  if (!board || board.columns.length === 0) {
+    return <span className='text-neutral-500 text-sm'>No columns yet</span>
+  }
+  return (
+    <div className='flex flex-row gap-2'>
+      {board.columns.map((columnId: string) => {
+        return (
+          <Button
+            key={columnId}
+            className='pl-2'
+            variant='secondary'
+            onClick={() => {
+              setColumnBeingModified(columnId)
+            }}
+          >
+            <span>{columns[columnId].name}</span>
+          </Button>
+        )
+      })}
+    </div>
+  )
+}
 
 export const ManageColumnsCard = () => {
   const { boardOrder, boards, columns } = usePlanner()
@@ -14,53 +72,13 @@ export const ManageColumnsCard = () => {
   const [columnBeingModified, setColumnBeingModified] = useState('')
   const [key, setKey] = useState(0)
 
+  // The selected board can be deleted from the boards card above; fall back to
+  // the first board so we never index `boards` with a stale id.
+  const activeBoardId = boards[selectedBoard] ? selectedBoard : boardOrder[0]
+
   const onCloseDialog = () => {
     setColumnBeingModified('')
     setKey((prevKey) => prevKey + 1) // Resets unsaved changes in dialog when cancel button is clicked
-  }
-
-  const BoardSelector = () => {
-    return (
-      <div className='flex flex-col gap-2 w-96'>
-        <Label htmlFor='board-selector'>Board</Label>
-        <Select onValueChange={(value) => setSelectedBoard(value)} defaultValue={selectedBoard}>
-          <SelectTrigger id='board-selector'>
-            <SelectValue placeholder='Select a board' />
-          </SelectTrigger>
-          <SelectContent>
-            {boardOrder.map((boardId: string) => (
-              <SelectItem key={boardId} value={boardId}>
-                {boards[boardId].name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-    )
-  }
-
-  const Columns = () => {
-    if (boards[selectedBoard].columns.length === 0) {
-      return <span className='text-neutral-500 text-sm'>No columns yet</span>
-    }
-    return (
-      <div className='flex flex-row gap-2'>
-        {boards[selectedBoard].columns.map((columnId: string) => {
-          return (
-            <Button
-              key={columnId}
-              className='pl-2'
-              variant='secondary'
-              onClick={() => {
-                setColumnBeingModified(columnId)
-              }}
-            >
-              <span>{columns[columnId].name}</span>
-            </Button>
-          )
-        })}
-      </div>
-    )
   }
 
   return (
@@ -70,14 +88,19 @@ export const ManageColumnsCard = () => {
           title='Columns'
           description="You won't usually need more than 3-4 columns, but you are free to add more."
         />
-        <BoardSelector />
-        <Columns />
-        <AddNewColumnButton boardId={selectedBoard} />
+        <BoardSelector
+          boardOrder={boardOrder}
+          boards={boards}
+          selectedBoard={activeBoardId}
+          setSelectedBoard={setSelectedBoard}
+        />
+        <Columns board={boards[activeBoardId]} columns={columns} setColumnBeingModified={setColumnBeingModified} />
+        <AddNewColumnButton boardId={activeBoardId} />
         {columnBeingModified && (
           <ModifyColumnDialogContent
             key={key}
             onCloseDialog={onCloseDialog}
-            boardId={selectedBoard}
+            boardId={activeBoardId}
             columnId={columnBeingModified}
           />
         )}

--- a/components/planner/Settings/ManageItemAlertDialog.tsx
+++ b/components/planner/Settings/ManageItemAlertDialog.tsx
@@ -30,17 +30,13 @@ export const ManageItemAlertDialog = ({
     <AlertDialog
       open={isOpen}
       onOpenChange={(newOpen) => {
+        // The stuck `pointer-events: none` on <body> after the simultaneous
+        // dialog + alert-dialog close (shadcn-ui/ui#1912) is cleaned up
+        // deterministically by ManageItemCardDialogWrapper when the parent
+        // dialog closes, so no workaround is needed here.
         if (!newOpen) {
           setIsOpen(false)
         }
-        // https://github.com/shadcn-ui/ui/issues/1912#issuecomment-2187447622
-        // The setTimeout is a workaround for a bug where after you clicked on an action on the alert dialog,
-        // both dialogs would close but the page would become unresponsive-- you couldn't click on anything.
-        setTimeout(() => {
-          if (!newOpen) {
-            document.body.style.pointerEvents = ''
-          }
-        }, 100)
       }}
     >
       <div className='flex justify-between items-end gap-2'>

--- a/components/planner/Settings/ManageItemCardDialogWrapper.tsx
+++ b/components/planner/Settings/ManageItemCardDialogWrapper.tsx
@@ -1,5 +1,5 @@
 import { Dialog } from '@/components/ui/dialog'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
 
 export const ManageItemCardDialogWrapper = ({
   children,
@@ -10,32 +10,27 @@ export const ManageItemCardDialogWrapper = ({
   onCloseDialog: () => void
   conditionToOpenDialog: boolean
 }) => {
-  const [isDialogOpen, setIsDialogOpen] = useState(false)
-
+  // When the nested AlertDialog confirms a delete, the Dialog and the
+  // AlertDialog close in the same update. Radix's dismissable layers race each
+  // other's cleanup and can leave `pointer-events: none` on <body>, freezing
+  // the page. https://github.com/shadcn-ui/ui/issues/1912
+  // Clearing the style once the dialog state has settled to closed (an effect,
+  // which runs after Radix's unmount cleanup) fixes this deterministically.
   useEffect(() => {
-    if (conditionToOpenDialog) {
-      setIsDialogOpen(true)
+    if (!conditionToOpenDialog) {
+      document.body.style.pointerEvents = ''
     }
   }, [conditionToOpenDialog])
 
-  function onOpenChangeHandler(newOpen: boolean) {
-    // shadcn / Radix UI is awful with nested dialogs. What a pain.
-    // https://github.com/shadcn-ui/ui/issues/1912#issuecomment-2187447622
-    // The setTimeout is a workaround for a bug where after you clicked on an action on the alert dialog,
-    // both dialogs would close but the page would become unresponsive-- you couldn't click on anything.
-    if (!newOpen) {
-      onCloseDialog()
-      setIsDialogOpen(false)
-    }
-    setTimeout(() => {
-      if (!newOpen) {
-        document.body.style.pointerEvents = ''
-      }
-    }, 100)
-  }
-
   return (
-    <Dialog open={isDialogOpen} onOpenChange={onOpenChangeHandler}>
+    <Dialog
+      open={conditionToOpenDialog}
+      onOpenChange={(newOpen) => {
+        if (!newOpen) {
+          onCloseDialog()
+        }
+      }}
+    >
       {children}
     </Dialog>
   )

--- a/components/planner/utils.ts
+++ b/components/planner/utils.ts
@@ -17,13 +17,6 @@ export const handleOnDragEnd: OnDragEndFunc = (result, dispatch, plannerContext,
   const { destination, source, draggableId, type } = result
   const { boards, columns, taskCards } = plannerContext
 
-  if (type === 'card') {
-    dispatch({
-      type: 'idOfCardBeingDraggedChanged',
-      payload: '',
-    })
-  }
-
   // Needed to fix bug where subtask drag handle would behave weirdly after being dropped in
   // position where it was originally dragged from
   if (type === 'subtask') {
@@ -61,11 +54,6 @@ export const handleOnDragStart: OnDragStartFunction = (dragStartObj, dispatch) =
     dispatch({
       type: 'subTaskDragStatusChanged',
       payload: true,
-    })
-  } else if (dragStartObj.type === 'card') {
-    dispatch({
-      type: 'idOfCardBeingDraggedChanged',
-      payload: dragStartObj.draggableId,
     })
   }
 }

--- a/hooks/Planner/Planner.tsx
+++ b/hooks/Planner/Planner.tsx
@@ -1,12 +1,12 @@
 import { emptyPlannerState, fetchPlannerData } from '@/utils/plannerUtils/apiClient'
 import axios from 'axios'
-import { Dispatch, createContext, useContext, useEffect, useReducer } from 'react'
+import { createContext, useContext, useEffect, useReducer } from 'react'
 import { useErrorBoundary } from 'react-error-boundary'
 import { plannerReducer } from './plannerReducer'
-import { PlannerType } from './types'
+import { PlannerDispatchContextType, PlannerType } from './types'
 
 export const PlannerContext = createContext<PlannerType>(emptyPlannerState)
-export const PlannerDispatchContext = createContext<Dispatch<any>>(() => {})
+export const PlannerDispatchContext = createContext<PlannerDispatchContextType>(() => {})
 
 export const usePlanner = () => {
   return useContext(PlannerContext)

--- a/hooks/Planner/plannerReducer.tsx
+++ b/hooks/Planner/plannerReducer.tsx
@@ -1,8 +1,8 @@
 import { UNASSIGNED_CATEGORY_ID } from '@/constants/constants'
 import { Draft, produce } from 'immer'
-import { PlannerType } from './types'
+import { PlannerAction, PlannerType } from './types'
 
-export const plannerReducer = produce((draft: Draft<PlannerType>, action) => {
+export const plannerReducer = produce((draft: Draft<PlannerType>, action: PlannerAction) => {
   switch (action.type) {
     case 'dataFetchedFromDatabase': {
       return action.payload
@@ -61,11 +61,6 @@ export const plannerReducer = produce((draft: Draft<PlannerType>, action) => {
       const { sourceColumnId, destColumnId, sourceColumnTaskCardIds, destColumnTaskCardIds } = action.payload
       draft.columns[sourceColumnId].taskCards = sourceColumnTaskCardIds
       draft.columns[destColumnId].taskCards = destColumnTaskCardIds
-      break
-    }
-    // NO NEED
-    case 'idOfCardBeingDraggedChanged': {
-      draft.idOfCardBeingDragged = action.payload
       break
     }
     // NO NEED
@@ -190,6 +185,11 @@ export const plannerReducer = produce((draft: Draft<PlannerType>, action) => {
       })
       delete draft.categories[categoryId]
       break
+    }
+    default: {
+      // Exhaustiveness check: a new PlannerAction without a case here is a compile error.
+      const unhandled: never = action
+      return unhandled
     }
   }
 })

--- a/hooks/Planner/types.tsx
+++ b/hooks/Planner/types.tsx
@@ -17,7 +17,7 @@ export type TaskCardInfoType = {
   title: string
   category: string
   content: string
-  status: 'created' | 'archived' | 'completed' | 'deleted'
+  status: 'created' | 'archived' | 'completed'
   subTasks: string[]
 }
 
@@ -66,9 +66,6 @@ export type BoardsType = {
 // DragDropContext component. This is why this state is in the parent, while it's being used way below
 // in the component tree.
 
-// idOfCardBeingDragged - Used to handle transparency of card while being dragged. isDragging could't be used because of
-// a decision to use a wrapper component which made passing the isDragging prop very tricky
-
 // taskCardBeingInitialized - Contains data of card that's being initialized. Didn't make sense to keep this in the store, since the data
 // is only changed in a few places.
 
@@ -78,7 +75,6 @@ export type BoardsType = {
 export type PlannerType = {
   hasLoaded: boolean
   isSubTaskBeingDragged: boolean
-  idOfCardBeingDragged: string
   taskCardBeingInitialized: TaskCardBeingInitializedType | null
   dataEnteredInTaskCardBeingInitialized: boolean
   boardOrder: string[]
@@ -89,4 +85,60 @@ export type PlannerType = {
   subTasks: SubTasksType
 }
 
-export type PlannerDispatchContextType = Dispatch<any>
+// One discriminated union for every reducer action, so dispatch sites get
+// compile-time payload checking and the reducer switch can be exhaustive.
+export type PlannerAction =
+  | { type: 'dataFetchedFromDatabase'; payload: PlannerType }
+  | {
+      type: 'newBoardAdded'
+      payload: { boardId: string; boardName: string; unassignedCategoryDetails: TaskCategoryType }
+    }
+  | { type: 'boardNameChanged'; payload: { boardId: string; newName: string } }
+  | { type: 'boardDeleted'; payload: { boardId: string } }
+  | {
+      type: 'newColumnAdded'
+      payload: { boardId: string; newColumnDetails: ColumnInfoType; updatedColumns: string[] }
+    }
+  | { type: 'columnDeleted'; payload: { boardId: string; columnId: string } }
+  | { type: 'columnNameChanged'; payload: { columnId: string; newName: string } }
+  | { type: 'columnsReordered'; payload: { boardId: string; newColumnOrder: string[] } }
+  | { type: 'cardMovedWithinColumn'; payload: { columnId: string; reorderedCardIds: string[] } }
+  | {
+      type: 'cardMovedAcrossColumns'
+      payload: {
+        sourceColumnId: string
+        destColumnId: string
+        sourceColumnTaskCardIds: string[]
+        destColumnTaskCardIds: string[]
+      }
+    }
+  | { type: 'taskCardInitializationCancelled'; payload?: null }
+  | { type: 'newTaskCardInitialized'; payload: TaskCardBeingInitializedType }
+  | { type: 'taskCardBeingInitializedHighlightStatusChange'; payload: boolean }
+  | { type: 'dataEnteredInTaskCardBeingInitializedStatusChanged'; payload: boolean }
+  | {
+      type: 'newTaskCardAdded'
+      payload: { columnId: string; newTaskCardDetails: TaskCardInfoType; updatedTaskCards: string[] }
+    }
+  | { type: 'taskCardCheckedStatusChanged'; payload: { columnId: string; taskCardId: string; isChecked: boolean } }
+  | { type: 'taskCardTitleChanged'; payload: { taskCardId: string; newTitle: string } }
+  | { type: 'taskCardContentChanged'; payload: { taskCardId: string; newContent: string } }
+  | { type: 'taskCardDeleted'; payload: { columnId: string; taskCardId: string } }
+  | { type: 'subTaskDragStatusChanged'; payload: boolean }
+  | { type: 'subTasksReordered'; payload: { taskCardId: string; reorderedSubTasks: string[] } }
+  | { type: 'subTasksCheckedStatusChanged'; payload: { subTaskId: string; isChecked: boolean } }
+  | { type: 'subTaskTitleChanged'; payload: { subTaskId: string; newTitle: string } }
+  | {
+      type: 'newSubTaskAdded'
+      payload: { taskCardId: string; newSubTaskDetails: SubTaskInfoType; newSubTasksOrder: string[] }
+    }
+  | {
+      type: 'subTaskDeletedOnBackspaceKeydown'
+      payload: { taskCardId: string; subTaskId: string; newSubtasks: string[] }
+    }
+  | { type: 'taskCategoryChanged'; payload: { taskCardId: string; newCategoryId: string } }
+  | { type: 'newCategoryAdded'; payload: { boardId: string; newCategoryDetails: TaskCategoryType } }
+  | { type: 'categoryInfoChanged'; payload: { categoryDetails: TaskCategoryType } }
+  | { type: 'categoryDeleted'; payload: { boardId: string; categoryId: string } }
+
+export type PlannerDispatchContextType = Dispatch<PlannerAction>

--- a/hooks/PlannerFilters/PlannerFilters.tsx
+++ b/hooks/PlannerFilters/PlannerFilters.tsx
@@ -7,9 +7,16 @@ type PlannerFiltersType = {
   selectedCategories: string[]
 }
 
-const plannerFiltersReducer = produce((draft: Draft<PlannerFiltersType>, action) => {
+export type PlannerFiltersAction =
+  | { type: 'selectedCategoriesChanged'; payload: { clickedCategory: string } }
+  | { type: 'searchQueryChanged'; payload: { searchQuery: string } }
+  | { type: 'filtersReset' }
+
+export type PlannerFiltersDispatchType = Dispatch<PlannerFiltersAction>
+
+const plannerFiltersReducer = produce((draft: Draft<PlannerFiltersType>, action: PlannerFiltersAction) => {
   switch (action.type) {
-    case 'selectedCategoriesChanged':
+    case 'selectedCategoriesChanged': {
       const { clickedCategory } = action.payload
       if (draft.selectedCategories.indexOf(clickedCategory) === -1) {
         draft.selectedCategories.push(clickedCategory)
@@ -17,14 +24,17 @@ const plannerFiltersReducer = produce((draft: Draft<PlannerFiltersType>, action)
         draft.selectedCategories = draft.selectedCategories.filter((cat: string) => cat != clickedCategory)
       }
       break
-    case 'searchQueryChanged':
+    }
+    case 'searchQueryChanged': {
       const { searchQuery } = action.payload
       draft.searchQuery = searchQuery
       break
-    case 'filtersReset':
+    }
+    case 'filtersReset': {
       draft.searchQuery = ''
       draft.selectedCategories = []
       break
+    }
   }
 })
 
@@ -35,7 +45,7 @@ const initialPlannerFilterEmptyState: PlannerFiltersType = {
 }
 
 export const PlannerFiltersContext = createContext<PlannerFiltersType>(initialPlannerFilterEmptyState)
-export const PlannerFiltersDispatchContext = createContext<Dispatch<any>>(() => {})
+export const PlannerFiltersDispatchContext = createContext<PlannerFiltersDispatchType>(() => {})
 
 export const usePlannerFilters = () => {
   return useContext(PlannerFiltersContext)

--- a/utils/plannerUtils/apiClient.ts
+++ b/utils/plannerUtils/apiClient.ts
@@ -1,15 +1,13 @@
 import { DEBOUNCE_TIME_MS } from '@/constants/constants'
-import { PlannerType } from '@/hooks/Planner/types'
+import { PlannerDispatchContextType, PlannerType } from '@/hooks/Planner/types'
 import axios from 'axios'
 import { DebouncedFunc } from 'lodash'
 import debounce from 'lodash/debounce'
-import { Dispatch } from 'react'
 import { toast } from 'sonner'
 
 export const emptyPlannerState: PlannerType = {
   hasLoaded: false,
   isSubTaskBeingDragged: false,
-  idOfCardBeingDragged: '',
   taskCardBeingInitialized: null,
   dataEnteredInTaskCardBeingInitialized: false,
   boardOrder: [],
@@ -48,7 +46,7 @@ export async function fetchPlannerData(signal?: AbortSignal): Promise<PlannerTyp
 let writeChain: Promise<unknown> = Promise.resolve()
 let refetchScheduled = false
 
-export function sendMutation(dispatch: Dispatch<any>, request: () => Promise<unknown>): void {
+export function sendMutation(dispatch: PlannerDispatchContextType, request: () => Promise<unknown>): void {
   writeChain = writeChain.then(request).catch((error) => {
     console.error('Mutation failed:', error)
     if (refetchScheduled) {
@@ -74,12 +72,12 @@ export function sendMutation(dispatch: Dispatch<any>, request: () => Promise<unk
  * editing card A's title and then clicking into card B within 500ms silently
  * cancelled A's save forever.
  */
-const debouncedSenders = new Map<string, DebouncedFunc<(dispatch: Dispatch<any>, request: () => Promise<unknown>) => void>>()
+const debouncedSenders = new Map<string, DebouncedFunc<(dispatch: PlannerDispatchContextType, request: () => Promise<unknown>) => void>>()
 
-export function sendDebouncedMutation(key: string, dispatch: Dispatch<any>, request: () => Promise<unknown>): void {
+export function sendDebouncedMutation(key: string, dispatch: PlannerDispatchContextType, request: () => Promise<unknown>): void {
   let sender = debouncedSenders.get(key)
   if (!sender) {
-    sender = debounce((latestDispatch: Dispatch<any>, latestRequest: () => Promise<unknown>) => {
+    sender = debounce((latestDispatch: PlannerDispatchContextType, latestRequest: () => Promise<unknown>) => {
       debouncedSenders.delete(key)
       sendMutation(latestDispatch, latestRequest)
     }, DEBOUNCE_TIME_MS)

--- a/utils/plannerUtils/boardUtils/addNewBoardToPlanner.ts
+++ b/utils/plannerUtils/boardUtils/addNewBoardToPlanner.ts
@@ -1,9 +1,9 @@
 import { UNASSIGNED_CATEGORY_COLOR, UNASSIGNED_CATEGORY_ID, UNASSIGNED_CATEGORY_NAME } from '@/constants/constants'
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendMutation } from '../apiClient'
 
-export const addNewBoardToPlanner = (boardId: string, boardName: string, dispatch: Dispatch<any>) => {
+export const addNewBoardToPlanner = (boardId: string, boardName: string, dispatch: PlannerDispatchContextType) => {
   const unassignedCategoryDetails = {
     id: UNASSIGNED_CATEGORY_ID,
     name: UNASSIGNED_CATEGORY_NAME,

--- a/utils/plannerUtils/boardUtils/changeBoardInfo.ts
+++ b/utils/plannerUtils/boardUtils/changeBoardInfo.ts
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendMutation } from '../apiClient'
 
-export const changeBoardInfo = (boardId: string, newName: string, dispatch: Dispatch<any>) => {
+export const changeBoardInfo = (boardId: string, newName: string, dispatch: PlannerDispatchContextType) => {
   dispatch({
     type: 'boardNameChanged',
     payload: {

--- a/utils/plannerUtils/boardUtils/deleteBoard.ts
+++ b/utils/plannerUtils/boardUtils/deleteBoard.ts
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendMutation } from '../apiClient'
 
-export default function deleteBoard(boardId: string, dispatch: Dispatch<any>) {
+export default function deleteBoard(boardId: string, dispatch: PlannerDispatchContextType) {
   dispatch({
     type: 'boardDeleted',
     payload: {

--- a/utils/plannerUtils/cardUtils/addNewCardToColumn.ts
+++ b/utils/plannerUtils/cardUtils/addNewCardToColumn.ts
@@ -1,6 +1,6 @@
 import { ColumnInfoType, TaskCardInfoType } from '@/hooks/Planner/types'
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendMutation } from '../apiClient'
 
 export const addNewCardToColumn = (
@@ -11,7 +11,7 @@ export const addNewCardToColumn = (
     category: string
     content: string
   },
-  dispatch: Dispatch<any>
+  dispatch: PlannerDispatchContextType
 ) => {
   const newTaskCardDetails: TaskCardInfoType = {
     id: cardDetails.id,

--- a/utils/plannerUtils/cardUtils/changeCardCategory.ts
+++ b/utils/plannerUtils/cardUtils/changeCardCategory.ts
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendMutation } from '../apiClient'
 
-export default function changeCardCategory(taskCardId: string, newCategoryId: string, dispatch: Dispatch<any>) {
+export default function changeCardCategory(taskCardId: string, newCategoryId: string, dispatch: PlannerDispatchContextType) {
   dispatch({
     type: 'taskCategoryChanged',
     payload: {

--- a/utils/plannerUtils/cardUtils/changeCardCheckedStatus.ts
+++ b/utils/plannerUtils/cardUtils/changeCardCheckedStatus.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendMutation } from '../apiClient'
 
 export default function changeCardCheckedStatus(
@@ -7,7 +7,7 @@ export default function changeCardCheckedStatus(
   taskCardId: string,
   isChecked: boolean,
   columnTaskCardIds: string[],
-  dispatch: Dispatch<any>
+  dispatch: PlannerDispatchContextType
 ) {
   dispatch({
     type: 'taskCardCheckedStatusChanged',

--- a/utils/plannerUtils/cardUtils/changeCardContent.ts
+++ b/utils/plannerUtils/cardUtils/changeCardContent.ts
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendDebouncedMutation } from '../apiClient'
 
-export default function changeCardContent(taskCardId: string, newContent: string, dispatch: Dispatch<any>) {
+export default function changeCardContent(taskCardId: string, newContent: string, dispatch: PlannerDispatchContextType) {
   dispatch({
     type: 'taskCardContentChanged',
     payload: {

--- a/utils/plannerUtils/cardUtils/changeCardTitle.ts
+++ b/utils/plannerUtils/cardUtils/changeCardTitle.ts
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendDebouncedMutation } from '../apiClient'
 
-export default function changeCardTitle(taskCardId: string, newTitle: string, dispatch: Dispatch<any>) {
+export default function changeCardTitle(taskCardId: string, newTitle: string, dispatch: PlannerDispatchContextType) {
   dispatch({
     type: 'taskCardTitleChanged',
     payload: {

--- a/utils/plannerUtils/cardUtils/deleteCard.ts
+++ b/utils/plannerUtils/cardUtils/deleteCard.ts
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendMutation } from '../apiClient'
 
-export default function deleteCard(columnId: string, taskCardId: string, dispatch: Dispatch<any>) {
+export default function deleteCard(columnId: string, taskCardId: string, dispatch: PlannerDispatchContextType) {
   dispatch({
     type: 'taskCardDeleted',
     payload: {

--- a/utils/plannerUtils/cardUtils/moveCardAcrossColumns.ts
+++ b/utils/plannerUtils/cardUtils/moveCardAcrossColumns.ts
@@ -1,7 +1,7 @@
 import { ColumnsType } from '@/hooks/Planner/types'
 import type { DraggableLocation } from '@hello-pangea/dnd'
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendMutation } from '../apiClient'
 
 export default function moveCardAcrossColumns(
@@ -9,7 +9,7 @@ export default function moveCardAcrossColumns(
   draggedCardId: string,
   source: DraggableLocation,
   destination: DraggableLocation,
-  dispatch: Dispatch<any>
+  dispatch: PlannerDispatchContextType
 ) {
   const sourceColumnId = source.droppableId
   const sourceColumn = columns[sourceColumnId]

--- a/utils/plannerUtils/cardUtils/moveCardWithinColumn.ts
+++ b/utils/plannerUtils/cardUtils/moveCardWithinColumn.ts
@@ -1,6 +1,6 @@
 import { ColumnsType } from '@/hooks/Planner/types'
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendMutation } from '../apiClient'
 
 export default function moveCardWithinColumn(
@@ -9,7 +9,7 @@ export default function moveCardWithinColumn(
   cardId: string,
   sourceIndex: number,
   destIndex: number,
-  dispatch: Dispatch<any>
+  dispatch: PlannerDispatchContextType
 ) {
   const startingColumn = columns[columnId]
   const reorderedCardIds = Array.from(startingColumn.taskCards) // Copy of taskCards

--- a/utils/plannerUtils/categoryUtils/addNewCategory.ts
+++ b/utils/plannerUtils/categoryUtils/addNewCategory.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendMutation } from '../apiClient'
 
 export const addNewCategory = (
@@ -9,7 +9,7 @@ export const addNewCategory = (
     name: string
     color: string
   },
-  dispatch: Dispatch<any>
+  dispatch: PlannerDispatchContextType
 ) => {
   dispatch({
     type: 'newCategoryAdded',

--- a/utils/plannerUtils/categoryUtils/changeCategoryInfo.ts
+++ b/utils/plannerUtils/categoryUtils/changeCategoryInfo.ts
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendMutation } from '../apiClient'
 
-export const changeCategoryInfo = (categoryId: string, newName: string, newColor: string, dispatch: Dispatch<any>) => {
+export const changeCategoryInfo = (categoryId: string, newName: string, newColor: string, dispatch: PlannerDispatchContextType) => {
   const categoryDetails = {
     id: categoryId,
     name: newName,

--- a/utils/plannerUtils/categoryUtils/deleteCategory.ts
+++ b/utils/plannerUtils/categoryUtils/deleteCategory.ts
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendMutation } from '../apiClient'
 
-export default function deleteCategory(boardId: string, categoryId: string, dispatch: Dispatch<any>) {
+export default function deleteCategory(boardId: string, categoryId: string, dispatch: PlannerDispatchContextType) {
   dispatch({
     type: 'categoryDeleted',
     payload: {

--- a/utils/plannerUtils/columnUtils/addNewColumn.ts
+++ b/utils/plannerUtils/columnUtils/addNewColumn.ts
@@ -1,10 +1,10 @@
 import { NANOID } from '@/constants/constants'
 import { BoardInfoType } from '@/hooks/Planner/types'
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendMutation } from '../apiClient'
 
-export const addNewColumn = (board: BoardInfoType, newColumnName: string, dispatch: Dispatch<any>) => {
+export const addNewColumn = (board: BoardInfoType, newColumnName: string, dispatch: PlannerDispatchContextType) => {
   const newColumnId = NANOID()
   const newColumnDetails = {
     id: newColumnId,

--- a/utils/plannerUtils/columnUtils/changeColumnName.ts
+++ b/utils/plannerUtils/columnUtils/changeColumnName.ts
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendMutation } from '../apiClient'
 
-export default function changeColumnName(columnId: string, newName: string, dispatch: Dispatch<any>) {
+export default function changeColumnName(columnId: string, newName: string, dispatch: PlannerDispatchContextType) {
   dispatch({
     type: 'columnNameChanged',
     payload: {

--- a/utils/plannerUtils/columnUtils/changeColumnOrder.ts
+++ b/utils/plannerUtils/columnUtils/changeColumnOrder.ts
@@ -1,6 +1,6 @@
 import { BoardsType } from '@/hooks/Planner/types'
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendMutation } from '../apiClient'
 
 export const changeColumnOrder = (
@@ -9,7 +9,7 @@ export const changeColumnOrder = (
   draggableId: string,
   sourceIndex: number,
   destIndex: number,
-  dispatch: Dispatch<any>
+  dispatch: PlannerDispatchContextType
 ) => {
   const newColumnOrder = Array.from(boards[boardId].columns)
   newColumnOrder.splice(sourceIndex, 1)

--- a/utils/plannerUtils/columnUtils/deleteColumn.ts
+++ b/utils/plannerUtils/columnUtils/deleteColumn.ts
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendMutation } from '../apiClient'
 
-export default function deleteColumn(boardId: string, columnId: string, dispatch: Dispatch<any>) {
+export default function deleteColumn(boardId: string, columnId: string, dispatch: PlannerDispatchContextType) {
   dispatch({
     type: 'columnDeleted',
     payload: {

--- a/utils/plannerUtils/subTaskUtils/addNewSubTaskToCard.ts
+++ b/utils/plannerUtils/subTaskUtils/addNewSubTaskToCard.ts
@@ -1,14 +1,14 @@
 import { NANOID } from '@/constants/constants'
 import { TaskCardInfoType } from '@/hooks/Planner/types'
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendMutation } from '../apiClient'
 
 const addNewSubTask = (
   taskCardId: string,
   newSubTaskId: string,
   newSubTasksOrder: string[],
-  dispatch: Dispatch<any>
+  dispatch: PlannerDispatchContextType
 ) => {
   const newSubTaskDetails = {
     id: newSubTaskId,
@@ -34,7 +34,7 @@ const addNewSubTask = (
 export const addNewSubTaskToCardOnEnterKeydown = (
   taskCard: TaskCardInfoType,
   existingSubTaskId: string,
-  dispatch: Dispatch<any>
+  dispatch: PlannerDispatchContextType
 ) => {
   const newSubTaskId = NANOID()
   const newSubTasksOrder = Array.from(taskCard.subTasks)
@@ -43,7 +43,7 @@ export const addNewSubTaskToCardOnEnterKeydown = (
   addNewSubTask(taskCard.id, newSubTaskId, newSubTasksOrder, dispatch)
 }
 
-export const addNewSubTaskOnButtonClick = (taskCard: TaskCardInfoType, dispatch: Dispatch<any>) => {
+export const addNewSubTaskOnButtonClick = (taskCard: TaskCardInfoType, dispatch: PlannerDispatchContextType) => {
   const newSubTaskId = NANOID()
   const newSubTasksOrder = Array.from(taskCard.subTasks)
   newSubTasksOrder.push(newSubTaskId)

--- a/utils/plannerUtils/subTaskUtils/changeSubTaskCheckedStatus.ts
+++ b/utils/plannerUtils/subTaskUtils/changeSubTaskCheckedStatus.ts
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendMutation } from '../apiClient'
 
-export default function changeSubTaskCheckedStatus(subTaskId: string, isChecked: boolean, dispatch: Dispatch<any>) {
+export default function changeSubTaskCheckedStatus(subTaskId: string, isChecked: boolean, dispatch: PlannerDispatchContextType) {
   dispatch({
     type: 'subTasksCheckedStatusChanged',
     payload: {

--- a/utils/plannerUtils/subTaskUtils/changeSubTaskTitle.ts
+++ b/utils/plannerUtils/subTaskUtils/changeSubTaskTitle.ts
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendDebouncedMutation } from '../apiClient'
 
-export default function changeSubTaskTitle(subTaskId: string, newTitle: string, dispatch: Dispatch<any>) {
+export default function changeSubTaskTitle(subTaskId: string, newTitle: string, dispatch: PlannerDispatchContextType) {
   dispatch({
     type: 'subTaskTitleChanged',
     payload: {

--- a/utils/plannerUtils/subTaskUtils/deleteSubTask.ts
+++ b/utils/plannerUtils/subTaskUtils/deleteSubTask.ts
@@ -1,9 +1,9 @@
 import { TaskCardInfoType } from '@/hooks/Planner/types'
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendMutation } from '../apiClient'
 
-export default function deleteSubTask(taskCard: TaskCardInfoType, subTaskId: string, dispatch: Dispatch<any>) {
+export default function deleteSubTask(taskCard: TaskCardInfoType, subTaskId: string, dispatch: PlannerDispatchContextType) {
   /* Moves cursor focus to subtask above using the subtask ID */
   const subTasksCopy = Array.from(taskCard.subTasks)
   const subTaskIndex = subTasksCopy.findIndex((id: string) => id === subTaskId)

--- a/utils/plannerUtils/subTaskUtils/reorderSubtasks.ts
+++ b/utils/plannerUtils/subTaskUtils/reorderSubtasks.ts
@@ -1,6 +1,6 @@
 import { TaskCardsType } from '@/hooks/Planner/types'
 import axios from 'axios'
-import { Dispatch } from 'react'
+import { PlannerDispatchContextType } from '@/hooks/Planner/types'
 import { sendMutation } from '../apiClient'
 
 export const reorderSubTasks = (
@@ -8,7 +8,7 @@ export const reorderSubTasks = (
   draggableId: string,
   sourceIndex: number,
   destIndex: number,
-  dispatch: Dispatch<any>
+  dispatch: PlannerDispatchContextType
 ) => {
   const [taskCardId, subTaskId] = draggableId.split('~')
   const reorderedSubTasks = Array.from(taskCards[taskCardId].subTasks)


### PR DESCRIPTION
Phase 4 of the post-dossier revitalization. The TypeScript and React & State dimensions:

- **`Dispatch<any>` × 31 → `Dispatch<PlannerAction>`**: one discriminated union over all 29 reducer actions, exhaustiveness-checked reducer. The compiler instantly surfaced the dossier's predicted missing-payload bug (CancelButton dispatching `dataEnteredInTaskCardBeingInitializedStatusChanged` with no payload) — fixed.
- **Drag state out of the global store**: card transparency uses `snapshot.isDragging` from the Draggable render prop instead of dispatching globally at drag start/end (the documented @hello-pangea/dnd anti-pattern). Dead action + state field removed end-to-end.
- **React.memo** on TaskCard / ColumnTasks / TaskColumn.
- **Filter+drag corruption**: dragging disabled while filters are active — filtered lists produced gapped Draggable indices, corrupting canonical order on drop.
- **Leaks**: portal-div-per-render in EditableSubTasks (one node per mount now); `form.watch()` subscription per keystroke (now in useEffect with cleanup).
- **Settings**: components-in-components hoisted in all 3 Manage cards, board-deletion crash fixed via fallback selection, the 100ms `pointerEvents` setTimeout hacks replaced with deterministic cleanup.
- Providerless `filtersReset` no-op removed, `'error occured lol'` → real console.error, stable list keys, dead `'deleted'` enum value dropped.

Verification: tsc clean, lint clean, production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)