### PR TITLE
Next.js standards + accessibility semantics

### DIFF
--- a/app/boards/[boardId]/page.tsx
+++ b/app/boards/[boardId]/page.tsx
@@ -2,19 +2,18 @@
 import { LoadingSpinner } from '@/components/global/LoadingSpinner'
 import { Board } from '@/components/planner/Board/Board'
 import { usePlanner } from '@/hooks/Planner/Planner'
-import { useRouter } from 'next/navigation'
+import { notFound } from 'next/navigation'
 
 export default function BoardPage({ params }: { params: { boardId: string } }) {
   const { hasLoaded, boards } = usePlanner()
   const { boardId } = params
-  const router = useRouter()
 
   if (!hasLoaded) {
     return <LoadingSpinner />
   }
 
   if (!boards[boardId]) {
-    return router.push('/not-found')
+    notFound()
   }
 
   return <Board boardId={boardId} />

--- a/app/boards/layout.tsx
+++ b/app/boards/layout.tsx
@@ -6,9 +6,10 @@ import { Toaster } from '@/components/ui/sonner'
 import { PlannerProvider } from '@/hooks/Planner/Planner'
 import { ClerkProvider } from '@clerk/nextjs'
 import { usePathname } from 'next/navigation'
+import { ReactNode } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 
-export default function Layout({ children }: { children: JSX.Element }) {
+export default function Layout({ children }: { children: ReactNode }) {
   const pathname = usePathname()
   const currentPage = pathname.split('/boards/')[1]
 

--- a/app/boards/loading.tsx
+++ b/app/boards/loading.tsx
@@ -1,0 +1,9 @@
+import { LoadingSpinner } from '@/components/global/LoadingSpinner'
+
+export default function Loading() {
+  return (
+    <div className='flex flex-1 justify-center items-center w-full'>
+      <LoadingSpinner />
+    </div>
+  )
+}

--- a/app/boards/new/page.tsx
+++ b/app/boards/new/page.tsx
@@ -11,7 +11,7 @@ export default function AddBoardCallout() {
 
   useEffect(() => {
     if (boardOrder.length > 0) {
-      router.push(`/boards/${boardOrder[0]}`)
+      router.replace(`/boards/${boardOrder[0]}`)
     }
   }, [boardOrder, router])
 

--- a/app/boards/page.tsx
+++ b/app/boards/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { LoadingSpinner } from '@/components/global/LoadingSpinner'
 import { usePlanner } from '@/hooks/Planner/Planner'
 import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
@@ -10,9 +11,9 @@ export default function PlannerPage() {
   useEffect(() => {
     if (hasLoaded) {
       const redirectPath = `/boards/${boardOrder.length > 0 ? boardOrder[0] : 'new'}`
-      router.push(redirectPath)
+      router.replace(redirectPath)
     }
   }, [hasLoaded, boardOrder, router])
 
-  return <></>
+  return <LoadingSpinner />
 }

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => {
+    console.error('Unhandled route error:', error)
+  }, [error])
+
+  return (
+    <main className='flex flex-col justify-center items-center gap-4 min-h-screen'>
+      <h1 className='font-semibold text-2xl'>Something went wrong</h1>
+      <p className='text-gray-500'>Sorry about that. You can try again.</p>
+      <button onClick={reset} className='text-blue-500 underline'>
+        Try again
+      </button>
+    </main>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,22 @@
+import type { Metadata } from 'next'
 import { Quicksand } from 'next/font/google'
+import { ReactNode } from 'react'
 import './globals.css'
 
 const quicksand = Quicksand({ subsets: ['latin'], weight: ['300', '400', '500', '600', '700'] })
 
-export default function RootLayout({ children }: { children: JSX.Element }) {
+export const metadata: Metadata = {
+  title: {
+    default: 'z-planner',
+    template: '%s · z-planner',
+  },
+  description: 'A Kanban-style planner. Boards, columns, drag-and-drop cards, subtasks, and categories.',
+}
+
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang='en' className={quicksand.className}>
-      <body suppressHydrationWarning>{children}</body>
+      <body>{children}</body>
     </html>
   )
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <main className='flex flex-col justify-center items-center gap-4 min-h-screen'>
+      <h1 className='font-semibold text-2xl'>Page not found</h1>
+      <p className='text-gray-500'>The page you are looking for does not exist.</p>
+      <Link href='/boards' className='text-blue-500 underline'>
+        Back to your boards
+      </Link>
+    </main>
+  )
+}

--- a/components/planner/Board/Sidebar/SidebarButton.tsx
+++ b/components/planner/Board/Sidebar/SidebarButton.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/components/ui/button'
-import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 
 export const SidebarButton = ({
   isCurrentlySelected,
@@ -12,23 +12,19 @@ export const SidebarButton = ({
   pathname: string
   icon?: React.ReactNode
 }) => {
-  const router = useRouter()
+  // A real link instead of a button calling router.push: middle-click, prefetch,
+  // and link semantics for free. Filters live in a provider that remounts with
+  // each board page, so navigation still resets them without an explicit dispatch.
   return (
-    <Button
-      variant={isCurrentlySelected ? 'default' : 'ghost'}
-      onClick={() => {
-        // Filters live in a provider that remounts with each board page, so
-        // navigation resets them without an explicit dispatch. The old dispatch
-        // here landed in a default context value and silently no-opped anyway.
-        router.push(pathname)
-      }}
-    >
-      <div className='flex justify-between gap-2 w-full'>
-        <div className='flex'>
-          {icon ? icon : <></>}
-          <span className='ml-5'>{label}</span>
+    <Button asChild variant={isCurrentlySelected ? 'default' : 'ghost'}>
+      <Link href={pathname} aria-current={isCurrentlySelected ? 'page' : undefined}>
+        <div className='flex justify-between gap-2 w-full'>
+          <div className='flex'>
+            {icon ? icon : <></>}
+            <span className='ml-5'>{label}</span>
+          </div>
         </div>
-      </div>
+      </Link>
     </Button>
   )
 }

--- a/components/planner/Board/TaskColumns/AddNewCardButton.tsx
+++ b/components/planner/Board/TaskColumns/AddNewCardButton.tsx
@@ -17,36 +17,38 @@ export const AddNewCardButton = ({ columnId }: { columnId: string }) => {
   return (
     <TooltipProvider delayDuration={0}>
       <Tooltip>
-        <TooltipTrigger>
-          <FaPlus
-            className='text-gray-400'
-            onClick={() => {
-              // Only allow an initializing task card to be added in an existing task card doesn't already exist,
-              // or if it exists and does not have any info entered and the add button is clicked from another
-              // column
-              if (
-                !taskCardBeingInitialized ||
-                (taskCardBeingInitialized &&
-                  !dataEnteredInTaskCardBeingInitialized &&
-                  taskCardBeingInitialized.columnId !== columnId)
-              ) {
-                const newTaskCardId = NANOID()
-                dispatch({
-                  type: 'newTaskCardInitialized',
-                  payload: {
-                    taskCardId: newTaskCardId,
-                    columnId,
-                    isHighlighted: false,
-                  },
-                })
-              } else {
-                dispatch({
-                  type: 'taskCardBeingInitializedHighlightStatusChange',
-                  payload: true,
-                })
-              }
-            }}
-          />
+        {/* TooltipTrigger renders a real <button>; the click handler lives on it
+            (not the svg) so the action is reachable by keyboard. */}
+        <TooltipTrigger
+          aria-label='Add new card'
+          onClick={() => {
+            // Only allow an initializing task card to be added in an existing task card doesn't already exist,
+            // or if it exists and does not have any info entered and the add button is clicked from another
+            // column
+            if (
+              !taskCardBeingInitialized ||
+              (taskCardBeingInitialized &&
+                !dataEnteredInTaskCardBeingInitialized &&
+                taskCardBeingInitialized.columnId !== columnId)
+            ) {
+              const newTaskCardId = NANOID()
+              dispatch({
+                type: 'newTaskCardInitialized',
+                payload: {
+                  taskCardId: newTaskCardId,
+                  columnId,
+                  isHighlighted: false,
+                },
+              })
+            } else {
+              dispatch({
+                type: 'taskCardBeingInitializedHighlightStatusChange',
+                payload: true,
+              })
+            }
+          }}
+        >
+          <FaPlus className='text-gray-400' />
         </TooltipTrigger>
         <TooltipContent>Add new card</TooltipContent>
       </Tooltip>

--- a/components/planner/Board/TaskColumns/TaskCard/CategoryBadge.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/CategoryBadge.tsx
@@ -26,10 +26,10 @@ export const CategoryBadge = ({ boardId, taskCardId }: CategoryBadgeProps) => {
         <Badge className={badgeClassNames[categoryInfo.color]}>{categoryInfo.name}</Badge>
       </DropdownMenuTrigger>
       <DropdownMenuContent className='w-56'>
-        {categoriesInBoard.map((categoryId, index) => (
+        {categoriesInBoard.map((categoryId) => (
           <DropdownMenuCheckboxItem
-            key={index}
-            checked={categoryInfo.name === categories[categoryId].name}
+            key={categoryId}
+            checked={taskCards[taskCardId].category === categoryId}
             onClick={(event) => {
               event.preventDefault()
               changeCardCategory(taskCardId, categoryId, dispatch)

--- a/components/planner/Board/TaskColumns/TaskCard/SubTasks.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/SubTasks.tsx
@@ -16,7 +16,7 @@ export const SubTasks = ({ taskCardId }: SubTasksProps) => {
       {subTasksUnderTaskCard.map((subTask, index) => (
         <div key={subTask.id} className='flex items-center gap-2'>
           <Checkbox
-            id={`${index}`}
+            id={`subtask-check-${subTask.id}`}
             checked={subTask.checked}
             onClick={(event) => {
               if (isEditable) {
@@ -26,7 +26,7 @@ export const SubTasks = ({ taskCardId }: SubTasksProps) => {
               }
             }}
           />
-          <label htmlFor={subTask.id} className='text-gray-500 text-sm cursor-pointer'>
+          <label htmlFor={`subtask-check-${subTask.id}`} className='text-gray-500 text-sm cursor-pointer'>
             {subTask.title}
           </label>
         </div>

--- a/components/planner/Board/TaskColumns/TaskCard/TaskCard.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/TaskCard.tsx
@@ -75,6 +75,17 @@ export const TaskCard = memo(function TaskCard({
     >
       {(isDragging) => (
         <Card
+          // DialogTrigger asChild attaches the open handler here; the card itself
+          // is a div, so it needs button semantics to be keyboard-openable.
+          role='button'
+          tabIndex={0}
+          aria-label={`Open task "${task.title}"`}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault()
+              event.currentTarget.click()
+            }
+          }}
           className={cn(
             isDragging ? 'backdrop-blur-sm bg-white/70' : '',
             task.status === 'completed' ? 'opacity-50' : ''

--- a/components/planner/Board/TaskColumns/TaskCard/TaskCardContextMenu/ContextMenuWrapper.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/TaskCardContextMenu/ContextMenuWrapper.tsx
@@ -14,7 +14,7 @@ import deleteCard from '@/utils/plannerUtils/cardUtils/deleteCard'
 type ContextMenuWrapperProps = {
   columnId: string
   taskCardId: string
-  children: JSX.Element
+  children: React.ReactNode
 }
 
 export const ContextMenuWrapper = ({ columnId, taskCardId, children }: ContextMenuWrapperProps) => {

--- a/components/planner/Board/TaskColumns/TaskCard/TaskCardDialog/AddNewSubTaskButton.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/TaskCardDialog/AddNewSubTaskButton.tsx
@@ -13,7 +13,9 @@ export const AddNewSubTaskButton = ({ taskCardId }: AddNewSubTaskButtonProps) =>
   const { taskCards, isSubTaskBeingDragged } = usePlanner()
 
   return (
-    <div
+    <button
+      type='button'
+      aria-label='Add subtask'
       className='flex items-center gap-2 mt-1 hover:cursor-pointer'
       onMouseEnter={() => setIsHoveringOver(true)}
       onMouseLeave={() => setIsHoveringOver(false)}
@@ -27,6 +29,6 @@ export const AddNewSubTaskButton = ({ taskCardId }: AddNewSubTaskButtonProps) =>
       <span className={`ml-2 text-sm ${isHoveringOver && !isSubTaskBeingDragged ? 'text-blue-500' : 'text-gray-400'}`}>
         Add subtask
       </span>
-    </div>
+    </button>
   )
 }

--- a/components/planner/Board/TaskColumns/TaskCard/TaskCardDialog/EditableSubTasks/EditableSubTask.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/TaskCardDialog/EditableSubTasks/EditableSubTask.tsx
@@ -35,7 +35,9 @@ export const EditableSubTask = ({ index, provided, taskCardId, subTask, isBeingD
         setShowDragHandle(false)
       }}
     >
-      <div {...provided.dragHandleProps} className={showDragHandle ? 'visible' : 'invisible'}>
+      {/* focus-visible keeps the handle reachable by keyboard (dnd's dragHandleProps
+          make it focusable) without changing the mouse hover behavior */}
+      <div {...provided.dragHandleProps} className={showDragHandle ? 'visible' : 'invisible focus-visible:visible'}>
         <GripVertical size={14} />
       </div>
       <Checkbox

--- a/components/planner/Board/TaskColumns/TaskCard/TaskCardDialog/TaskCardDialog.tsx
+++ b/components/planner/Board/TaskColumns/TaskCard/TaskCardDialog/TaskCardDialog.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
-import { DialogContent } from '@/components/ui/dialog'
+import { DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { Separator } from '@/components/ui/separator'
 import { Textarea } from '@/components/ui/textarea'
 import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
@@ -23,6 +23,9 @@ export const TaskCardDialog = ({ boardId, columnId, id }: TaskCardDialogProps) =
 
   return (
     <DialogContent className='p-0'>
+      {/* Screen-reader-only title: Radix warns without one, and assistive tech
+          announces nothing when the dialog opens. */}
+      <DialogTitle className='sr-only'>{task.title || 'Task card'}</DialogTitle>
       <Card className='p-2'>
         <CardHeader className='gap-2 pb-0 pl-7'>
           <div className='flex gap-2'>

--- a/components/planner/Settings/ManageBoardsCard/AddNewBoardButton.tsx
+++ b/components/planner/Settings/ManageBoardsCard/AddNewBoardButton.tsx
@@ -25,7 +25,7 @@ export const AddNewBoardButton = () => {
         }
       }}
     >
-      <DialogTrigger>
+      <DialogTrigger asChild>
         <Button variant='outline'>
           <Plus className='mr-2 w-4 h-4' /> Add a new board
         </Button>

--- a/components/planner/Settings/ManageBoardsCard/ModifyBoardDialogContent.tsx
+++ b/components/planner/Settings/ManageBoardsCard/ModifyBoardDialogContent.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/components/ui/button'
-import { DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
@@ -44,7 +44,10 @@ export const ModifyBoardDialogContent = ({ onCloseDialog, boardId }: ModifyBoard
     <DialogContent>
       <DialogHeader>
         <DialogTitle className='mb-5'>Modify Board</DialogTitle>
-        <DialogDescription>
+        {/* A div, not DialogDescription: that component renders a <p>, and a form
+            inside a paragraph is invalid HTML that browsers re-parent. Classes
+            match DialogDescription so the rendering is identical. */}
+        <div className='text-sm text-muted-foreground'>
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)}>
               <FormField
@@ -81,7 +84,7 @@ export const ModifyBoardDialogContent = ({ onCloseDialog, boardId }: ModifyBoard
               </Button>
             </span>
           </div>
-        </DialogDescription>
+        </div>
       </DialogHeader>
     </DialogContent>
   )

--- a/components/planner/Settings/ManageCategoriesCard/AddNewCategoryButton.tsx
+++ b/components/planner/Settings/ManageCategoriesCard/AddNewCategoryButton.tsx
@@ -24,7 +24,7 @@ export const AddNewCategoryButton = () => {
         }
       }}
     >
-      <DialogTrigger>
+      <DialogTrigger asChild>
         <Button className='w-full' variant='outline'>
           <Plus className='mr-2 w-4 h-4' /> Add a new category
         </Button>

--- a/components/planner/Settings/ManageCategoriesCard/CategoryColorPicker.tsx
+++ b/components/planner/Settings/ManageCategoriesCard/CategoryColorPicker.tsx
@@ -15,7 +15,7 @@ type CategoryColorPickerProps = {
 export const CategoryColorPicker = ({ color, setColor }: CategoryColorPickerProps) => {
   return (
     <Popover modal={true}>
-      <PopoverTrigger>
+      <PopoverTrigger asChild>
         <Button variant='outline' className='justify-start w-[230px] font-normal'>
           <div className='flex items-center gap-2 w-full'>
             <div className={cn('h-4 w-4 rounded !bg-center !bg-cover transition-all', badgeClassNames[color])} />

--- a/components/planner/Settings/ManageCategoriesCard/ModifyCategoryDialogContent.tsx
+++ b/components/planner/Settings/ManageCategoriesCard/ModifyCategoryDialogContent.tsx
@@ -1,6 +1,6 @@
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -56,7 +56,10 @@ export const ModifyCategoryDialogContent = ({
     <DialogContent>
       <DialogHeader>
         <DialogTitle className='mb-5'>Modify Category</DialogTitle>
-        <DialogDescription>
+        {/* A div, not DialogDescription: that component renders a <p>, and a form
+            inside a paragraph is invalid HTML that browsers re-parent. Classes
+            match DialogDescription so the rendering is identical. */}
+        <div className='text-sm text-muted-foreground'>
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)}>
               <FormField
@@ -103,7 +106,7 @@ export const ModifyCategoryDialogContent = ({
               </Button>
             </span>
           </div>
-        </DialogDescription>
+        </div>
       </DialogHeader>
     </DialogContent>
   )

--- a/components/planner/Settings/ManageColumnsCard/AddNewColumnButton.tsx
+++ b/components/planner/Settings/ManageColumnsCard/AddNewColumnButton.tsx
@@ -25,7 +25,7 @@ export const AddNewColumnButton = ({ boardId }: { boardId: string }) => {
         }
       }}
     >
-      <DialogTrigger>
+      <DialogTrigger asChild>
         <Button variant='outline'>
           <Plus className='mr-2 w-4 h-4' /> Add a new column
         </Button>

--- a/components/planner/Settings/ManageColumnsCard/ModifyColumnDialogContent.tsx
+++ b/components/planner/Settings/ManageColumnsCard/ModifyColumnDialogContent.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/components/ui/button'
-import { DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { usePlanner, usePlannerDispatch } from '@/hooks/Planner/Planner'
@@ -45,7 +45,10 @@ export const ModifyColumnDialogContent = ({ onCloseDialog, boardId, columnId }: 
     <DialogContent>
       <DialogHeader>
         <DialogTitle className='mb-5'>Modify Column</DialogTitle>
-        <DialogDescription>
+        {/* A div, not DialogDescription: that component renders a <p>, and a form
+            inside a paragraph is invalid HTML that browsers re-parent. Classes
+            match DialogDescription so the rendering is identical. */}
+        <div className='text-sm text-muted-foreground'>
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)}>
               <FormField
@@ -82,7 +85,7 @@ export const ModifyColumnDialogContent = ({ onCloseDialog, boardId, columnId }: 
               </Button>
             </span>
           </div>
-        </DialogDescription>
+        </div>
       </DialogHeader>
     </DialogContent>
   )

--- a/components/planner/Settings/ManageItemAlertDialog.tsx
+++ b/components/planner/Settings/ManageItemAlertDialog.tsx
@@ -48,10 +48,15 @@ export const ManageItemAlertDialog = ({
         {isDeleteButtonDisabled && (
           <TooltipProvider delayDuration={0}>
             <Tooltip>
-              <TooltipTrigger className='cursor-default'>
-                <Button size='sm' variant='destructive' disabled={true}>
-                  Delete
-                </Button>
+              {/* asChild + focusable span: a disabled button swallows pointer events
+                  (the tooltip would never fire) and the old wrapper nested a button
+                  inside the trigger's own button — invalid HTML. */}
+              <TooltipTrigger asChild>
+                <span tabIndex={0} className='cursor-default'>
+                  <Button size='sm' variant='destructive' disabled={true}>
+                    Delete
+                  </Button>
+                </span>
               </TooltipTrigger>
               <TooltipContent>
                 <p>{deleteButtonDisabledTooltipContent}</p>

--- a/hooks/Planner/Planner.tsx
+++ b/hooks/Planner/Planner.tsx
@@ -1,6 +1,6 @@
 import { emptyPlannerState, fetchPlannerData } from '@/utils/plannerUtils/apiClient'
 import axios from 'axios'
-import { createContext, useContext, useEffect, useReducer } from 'react'
+import { ReactNode, createContext, useContext, useEffect, useReducer } from 'react'
 import { useErrorBoundary } from 'react-error-boundary'
 import { plannerReducer } from './plannerReducer'
 import { PlannerDispatchContextType, PlannerType } from './types'
@@ -16,7 +16,7 @@ export const usePlannerDispatch = () => {
   return useContext(PlannerDispatchContext)
 }
 
-export const PlannerProvider = ({ children }: { children: JSX.Element | JSX.Element[] }) => {
+export const PlannerProvider = ({ children }: { children: ReactNode }) => {
   const { showBoundary } = useErrorBoundary()
   const [plannerData, dispatch] = useReducer(plannerReducer, emptyPlannerState)
 

--- a/hooks/PlannerFilters/PlannerFilters.tsx
+++ b/hooks/PlannerFilters/PlannerFilters.tsx
@@ -1,5 +1,5 @@
 import { Draft, produce } from 'immer'
-import { Dispatch, createContext, useContext, useReducer } from 'react'
+import { Dispatch, ReactNode, createContext, useContext, useReducer } from 'react'
 
 type PlannerFiltersType = {
   area: string
@@ -55,7 +55,7 @@ export const usePlannerFiltersDispatch = () => {
   return useContext(PlannerFiltersDispatchContext)
 }
 
-export const PlannerFiltersProvider = ({ children }: { children: JSX.Element | JSX.Element[] }) => {
+export const PlannerFiltersProvider = ({ children }: { children: ReactNode }) => {
   const [plannerFiltersData, dispatch] = useReducer(plannerFiltersReducer, initialPlannerFilterEmptyState)
 
   return (


### PR DESCRIPTION
Phase 5 of the post-dossier revitalization.

**App Router conventions**: Metadata API (the deployed app finally has a `<title>`), `not-found.tsx`/`error.tsx`/`loading.tsx`, `notFound()` instead of a render-time `router.push` to a route that never existed, `router.replace` for redirects, spinner instead of blank screen on `/boards`, React-19-safe `ReactNode` children types, stray `suppressHydrationWarning` removed.

**Keyboard + semantics, zero visual changes**: cards open via keyboard (role/tabIndex/aria-label/Enter/Space), add-card and add-subtask are real buttons, drag handles visible on keyboard focus, sidebar is real links (middle-click/prefetch/aria-current), screen-reader DialogTitle on the edit dialog, forms out of `DialogDescription`'s `<p>` (invalid HTML → hydration mismatches), five button-in-button nestings fixed via `asChild`, checkbox/label ids matched, category checkmark compares ids not names.

**Deferred intentionally** (visual, out of scope per the brief): focus rings on text inputs, category color contrast, responsive layout, dark mode mounting.

Verification: tsc clean, lint clean, production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)