### PR TITLE
Redirect Vercel domain to custom domain (Clerk prod cutover)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,19 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  async redirects() {
+    return [
+      {
+        // Canonicalize the auto-assigned Vercel domain onto the custom domain
+        // where the Clerk production instance is configured. 307 during cutover
+        // so browsers don't hard-cache it; flip to permanent once stable.
+        source: '/:path*',
+        has: [{ type: 'host', value: 'zenith-planner.vercel.app' }],
+        destination: 'https://zplanner.faaez.co.in/:path*',
+        permanent: false,
+      },
+    ]
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
Adds a host-based 307 redirect from `zenith-planner.vercel.app` to `zplanner.faaez.co.in` in `next.config.js`.

The Clerk **production** instance is bound to `zplanner.faaez.co.in`. Production Clerk only sets first-party auth cookies on its configured domain, so traffic landing on the auto-assigned `*.vercel.app` URL can't authenticate. This canonicalizes everyone onto the working domain.

`permanent: false` (307) during cutover to avoid browser hard-caching; flip to `true` once stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)