### PR TITLE
Make Vercel->custom domain redirect permanent (308)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,12 +5,12 @@ const nextConfig = {
     return [
       {
         // Canonicalize the auto-assigned Vercel domain onto the custom domain
-        // where the Clerk production instance is configured. 307 during cutover
-        // so browsers don't hard-cache it; flip to permanent once stable.
+        // where the Clerk production instance is configured. Permanent (308)
+        // now that the cutover is verified stable.
         source: '/:path*',
         has: [{ type: 'host', value: 'zenith-planner.vercel.app' }],
         destination: 'https://zplanner.faaez.co.in/:path*',
-        permanent: false,
+        permanent: true,
       },
     ]
   },


### PR DESCRIPTION
Follow-up to #15. Cutover to `zplanner.faaez.co.in` is verified stable (Clerk production cert issued, sign-in working, Mongo restored), so promote the redirect from 307 to a permanent 308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)